### PR TITLE
feat: Add RISC-V enhancements for Neon

### DIFF
--- a/simde/arm/neon/add.h
+++ b/simde/arm/neon/add.h
@@ -567,6 +567,12 @@ simde_vaddq_s32(simde_int32x4_t a, simde_int32x4_t b) {
       r_.m128i = _mm_add_epi32(a_.m128i, b_.m128i);
     #elif defined(SIMDE_WASM_SIMD128_NATIVE)
       r_.v128 = wasm_i32x4_add(a_.v128, b_.v128);
+    #elif defined(SIMDE_RISCV_V_NATIVE) && (SIMDE_NATURAL_VECTOR_SIZE >= 64)
+      #if SIMDE_NATURAL_VECTOR_SIZE < 128
+        r_.sv128 = __riscv_vadd_vv_i32m1(a_.sv128 , b_.sv128 , 4);
+      #else
+        r_.sv128 = __riscv_vadd_vv_i32mf2(a_.sv128 , b_.sv128 , 4);
+      #endif
     #elif defined(SIMDE_VECTOR_SUBSCRIPT_OPS)
       r_.values = a_.values + b_.values;
     #else

--- a/simde/arm/neon/types.h
+++ b/simde/arm/neon/types.h
@@ -47,6 +47,15 @@ typedef union {
   #if defined(SIMDE_X86_MMX_NATIVE)
     __m64 m64;
   #endif
+
+  #if defined(SIMDE_RISCV_V_NATIVE)
+    #if SIMDE_NATURAL_VECTOR_SIZE >= 64 && SIMDE_NATURAL_VECTOR_SIZE < 128
+      fixed_vint8m1_t sv64;
+    #elif SIMDE_NATURAL_VECTOR_SIZE >= 128
+      fixed_vint8mf2_t sv64;
+    #endif
+  #endif
+
 } simde_int8x8_private;
 
 typedef union {
@@ -55,6 +64,15 @@ typedef union {
   #if defined(SIMDE_X86_MMX_NATIVE)
     __m64 m64;
   #endif
+
+  #if defined(SIMDE_RISCV_V_NATIVE)
+    #if SIMDE_NATURAL_VECTOR_SIZE >= 64 && SIMDE_NATURAL_VECTOR_SIZE < 128
+      fixed_vint16m1_t sv64;
+    #elif SIMDE_NATURAL_VECTOR_SIZE >= 128
+      fixed_vint16mf2_t sv64;
+    #endif
+  #endif
+
 } simde_int16x4_private;
 
 typedef union {
@@ -63,6 +81,15 @@ typedef union {
   #if defined(SIMDE_X86_MMX_NATIVE)
     __m64 m64;
   #endif
+
+  #if defined(SIMDE_RISCV_V_NATIVE)
+    #if SIMDE_NATURAL_VECTOR_SIZE >= 64 && SIMDE_NATURAL_VECTOR_SIZE < 128
+      fixed_vint32m1_t sv64;
+    #elif SIMDE_NATURAL_VECTOR_SIZE >= 128
+      fixed_vint32mf2_t sv64;
+    #endif
+  #endif
+
 } simde_int32x2_private;
 
 typedef union {
@@ -71,6 +98,11 @@ typedef union {
   #if defined(SIMDE_X86_MMX_NATIVE)
     __m64 m64;
   #endif
+
+  #if defined(SIMDE_RISCV_V_NATIVE) && SIMDE_NATURAL_VECTOR_SIZE >= 64
+      fixed_vint64m1_t sv64;
+  #endif
+
 } simde_int64x1_private;
 
 typedef union {
@@ -79,6 +111,15 @@ typedef union {
   #if defined(SIMDE_X86_MMX_NATIVE)
     __m64 m64;
   #endif
+
+  #if defined(SIMDE_RISCV_V_NATIVE)
+    #if SIMDE_NATURAL_VECTOR_SIZE >= 64 && SIMDE_NATURAL_VECTOR_SIZE < 128
+      fixed_vuint8m1_t sv64;
+    #elif SIMDE_NATURAL_VECTOR_SIZE >= 128
+      fixed_vuint8mf2_t sv64;
+    #endif
+  #endif
+
 } simde_uint8x8_private;
 
 typedef union {
@@ -87,6 +128,15 @@ typedef union {
   #if defined(SIMDE_X86_MMX_NATIVE)
     __m64 m64;
   #endif
+
+  #if defined(SIMDE_RISCV_V_NATIVE)
+    #if SIMDE_NATURAL_VECTOR_SIZE >= 64 && SIMDE_NATURAL_VECTOR_SIZE < 128
+      fixed_vuint16m1_t sv64;
+    #elif SIMDE_NATURAL_VECTOR_SIZE >= 128
+      fixed_vuint16mf2_t sv64;
+    #endif
+  #endif
+
 } simde_uint16x4_private;
 
 typedef union {
@@ -95,6 +145,15 @@ typedef union {
   #if defined(SIMDE_X86_MMX_NATIVE)
     __m64 m64;
   #endif
+
+  #if defined(SIMDE_RISCV_V_NATIVE)
+    #if SIMDE_NATURAL_VECTOR_SIZE >= 64 && SIMDE_NATURAL_VECTOR_SIZE < 128
+      fixed_vuint32m1_t sv64;
+    #elif SIMDE_NATURAL_VECTOR_SIZE >= 128
+      fixed_vuint32mf2_t sv64;
+    #endif
+  #endif
+
 } simde_uint32x2_private;
 
 typedef union {
@@ -103,6 +162,11 @@ typedef union {
   #if defined(SIMDE_X86_MMX_NATIVE)
     __m64 m64;
   #endif
+
+  #if defined(SIMDE_RISCV_V_NATIVE) && SIMDE_NATURAL_VECTOR_SIZE >= 64
+      fixed_vuint64m1_t sv64;
+  #endif
+
 } simde_uint64x1_private;
 
 typedef union {
@@ -115,6 +179,15 @@ typedef union {
   #if defined(SIMDE_X86_MMX_NATIVE)
     __m64 m64;
   #endif
+
+  #if defined(SIMDE_RISCV_V_NATIVE) && SIMDE_ARCH_RISCV_ZVFH
+    #if SIMDE_NATURAL_VECTOR_SIZE >= 64 && SIMDE_NATURAL_VECTOR_SIZE < 128
+      fixed_vfloat16m1_t sv64;
+    #elif SIMDE_NATURAL_VECTOR_SIZE >= 128
+      fixed_vfloat16mf2_t sv64;
+    #endif
+  #endif
+
 } simde_float16x4_private;
 
 typedef union {
@@ -123,6 +196,15 @@ typedef union {
   #if defined(SIMDE_X86_MMX_NATIVE)
     __m64 m64;
   #endif
+
+  #if defined(SIMDE_RISCV_V_NATIVE)
+    #if SIMDE_NATURAL_VECTOR_SIZE >= 64 && SIMDE_NATURAL_VECTOR_SIZE < 128
+      fixed_vfloat32m1_t sv64;
+    #elif SIMDE_NATURAL_VECTOR_SIZE >= 128
+      fixed_vfloat32mf2_t sv64;
+    #endif
+  #endif
+
 } simde_float32x2_private;
 
 typedef union {
@@ -131,6 +213,11 @@ typedef union {
   #if defined(SIMDE_X86_MMX_NATIVE)
     __m64 m64;
   #endif
+
+  #if defined(SIMDE_RISCV_V_NATIVE)
+      fixed_vfloat64m1_t sv64;
+  #endif
+
 } simde_float64x1_private;
 
 typedef union {
@@ -147,6 +234,15 @@ typedef union {
   #if defined(SIMDE_WASM_SIMD128_NATIVE)
     v128_t v128;
   #endif
+
+  #if defined(SIMDE_RISCV_V_NATIVE)
+    #if SIMDE_NATURAL_VECTOR_SIZE >= 64 && SIMDE_NATURAL_VECTOR_SIZE < 128
+      fixed_vint8m2_t sv128;
+    #elif SIMDE_NATURAL_VECTOR_SIZE >= 128
+      fixed_vint8m1_t sv128;
+    #endif
+  #endif
+
 } simde_int8x16_private;
 
 typedef union {
@@ -163,6 +259,15 @@ typedef union {
   #if defined(SIMDE_WASM_SIMD128_NATIVE)
     v128_t v128;
   #endif
+
+  #if defined(SIMDE_RISCV_V_NATIVE)
+    #if SIMDE_NATURAL_VECTOR_SIZE >= 64 && SIMDE_NATURAL_VECTOR_SIZE < 128
+      fixed_vint16m2_t sv128;
+    #elif SIMDE_NATURAL_VECTOR_SIZE >= 128
+      fixed_vint16m1_t sv128;
+    #endif
+  #endif
+
 } simde_int16x8_private;
 
 typedef union {
@@ -183,6 +288,15 @@ typedef union {
   #if defined(SIMDE_WASM_SIMD128_NATIVE)
     v128_t v128;
   #endif
+
+  #if defined(SIMDE_RISCV_V_NATIVE)
+    #if SIMDE_NATURAL_VECTOR_SIZE >= 64 && SIMDE_NATURAL_VECTOR_SIZE < 128
+      fixed_vint32m2_t sv128;
+    #elif SIMDE_NATURAL_VECTOR_SIZE >= 128
+      fixed_vint32m1_t sv128;
+    #endif
+  #endif
+
 } simde_int32x4_private;
 
 typedef union {
@@ -199,6 +313,15 @@ typedef union {
   #if defined(SIMDE_WASM_SIMD128_NATIVE)
     v128_t v128;
   #endif
+
+  #if defined(SIMDE_RISCV_V_NATIVE)
+    #if SIMDE_NATURAL_VECTOR_SIZE >= 64 && SIMDE_NATURAL_VECTOR_SIZE < 128
+      fixed_vint64m2_t sv128;
+    #elif SIMDE_NATURAL_VECTOR_SIZE >= 128
+      fixed_vint64m1_t sv128;
+    #endif
+  #endif
+
 } simde_int64x2_private;
 
 typedef union {
@@ -215,6 +338,15 @@ typedef union {
   #if defined(SIMDE_WASM_SIMD128_NATIVE)
     v128_t v128;
   #endif
+
+  #if defined(SIMDE_RISCV_V_NATIVE)
+    #if SIMDE_NATURAL_VECTOR_SIZE >= 64 && SIMDE_NATURAL_VECTOR_SIZE < 128
+      fixed_vuint8m2_t sv128;
+    #elif SIMDE_NATURAL_VECTOR_SIZE >= 128
+      fixed_vuint8m1_t sv128;
+    #endif
+  #endif
+
 } simde_uint8x16_private;
 
 typedef union {
@@ -231,6 +363,15 @@ typedef union {
   #if defined(SIMDE_WASM_SIMD128_NATIVE)
     v128_t v128;
   #endif
+
+  #if defined(SIMDE_RISCV_V_NATIVE)
+    #if SIMDE_NATURAL_VECTOR_SIZE >= 64 && SIMDE_NATURAL_VECTOR_SIZE < 128
+      fixed_vuint16m2_t sv128;
+    #elif SIMDE_NATURAL_VECTOR_SIZE >= 128
+      fixed_vuint16m1_t sv128;
+    #endif
+  #endif
+
 } simde_uint16x8_private;
 
 typedef union {
@@ -247,6 +388,15 @@ typedef union {
   #if defined(SIMDE_WASM_SIMD128_NATIVE)
     v128_t v128;
   #endif
+
+  #if defined(SIMDE_RISCV_V_NATIVE)
+    #if SIMDE_NATURAL_VECTOR_SIZE >= 64 && SIMDE_NATURAL_VECTOR_SIZE < 128
+      fixed_vuint32m2_t sv128;
+    #elif SIMDE_NATURAL_VECTOR_SIZE >= 128
+      fixed_vuint32m1_t sv128;
+    #endif
+  #endif
+
 } simde_uint32x4_private;
 
 typedef union {
@@ -263,6 +413,15 @@ typedef union {
   #if defined(SIMDE_WASM_SIMD128_NATIVE)
     v128_t v128;
   #endif
+
+  #if defined(SIMDE_RISCV_V_NATIVE)
+    #if SIMDE_NATURAL_VECTOR_SIZE >= 64 && SIMDE_NATURAL_VECTOR_SIZE < 128
+      fixed_vuint64m2_t sv128;
+    #elif SIMDE_NATURAL_VECTOR_SIZE >= 128
+      fixed_vuint64m1_t sv128;
+    #endif
+  #endif
+
 } simde_uint64x2_private;
 
 typedef union {
@@ -283,6 +442,15 @@ typedef union {
   #if defined(SIMDE_WASM_SIMD128_NATIVE)
     v128_t v128;
   #endif
+
+  #if defined(SIMDE_RISCV_V_NATIVE) && SIMDE_ARCH_RISCV_ZVFH
+    #if SIMDE_NATURAL_VECTOR_SIZE >= 64 && SIMDE_NATURAL_VECTOR_SIZE < 128
+      fixed_vfloat16m2_t sv128;
+    #elif SIMDE_NATURAL_VECTOR_SIZE >= 128
+      fixed_vfloat16m1_t sv128;
+    #endif
+  #endif
+
 } simde_float16x8_private;
 
 typedef union {
@@ -299,6 +467,15 @@ typedef union {
   #if defined(SIMDE_WASM_SIMD128_NATIVE)
     v128_t v128;
   #endif
+
+  #if defined(SIMDE_RISCV_V_NATIVE)
+    #if SIMDE_NATURAL_VECTOR_SIZE >= 64 && SIMDE_NATURAL_VECTOR_SIZE < 128
+      fixed_vfloat32m2_t sv128;
+    #elif SIMDE_NATURAL_VECTOR_SIZE >= 128
+      fixed_vfloat32m1_t sv128;
+    #endif
+  #endif
+
 } simde_float32x4_private;
 
 typedef union {
@@ -315,6 +492,15 @@ typedef union {
   #if defined(SIMDE_WASM_SIMD128_NATIVE)
     v128_t v128;
   #endif
+
+  #if defined(SIMDE_RISCV_V_NATIVE)
+    #if SIMDE_NATURAL_VECTOR_SIZE >= 64 && SIMDE_NATURAL_VECTOR_SIZE < 128
+      fixed_vfloat64m2_t sv128;
+    #elif SIMDE_NATURAL_VECTOR_SIZE >= 128
+      fixed_vfloat64m1_t sv128;
+    #endif
+  #endif
+
 } simde_float64x2_private;
 
 #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)

--- a/simde/simde-arch.h
+++ b/simde/simde-arch.h
@@ -476,8 +476,40 @@
   #define SIMDE_ARCH_POWER_ALTIVEC_CHECK(version) (0)
 #endif
 
-#if defined(__riscv) && __riscv_xlen==64
-#  define SIMDE_ARCH_RISCV64
+/* RISC-V
+   <https://en.wikipedia.org/wiki/RISC-V> */
+#if defined(__riscv) || defined(__riscv__)
+#  if __riscv_xlen == 64
+#     define SIMDE_ARCH_RISCV64
+#  elif __riscv_xlen == 32
+#     define SIMDE_ARCH_RISCV32
+#  endif
+#endif
+
+/* RISC-V SIMD ISA extensions */
+#if defined(__riscv_zve32x)
+#  define SIMDE_ARCH_RISCV_ZVE32X 1
+#endif
+#if defined(__riscv_zve32f)
+#  define SIMDE_ARCH_RISCV_ZVE32F 1
+#endif
+#if defined(__riscv_zve64x)
+#  define SIMDE_ARCH_RISCV_ZVE64X 1
+#endif
+#if defined(__riscv_zve64f)
+#  define SIMDE_ARCH_RISCV_ZVE64F 1
+#endif
+#if defined(__riscv_zve64d)
+#  define SIMDE_ARCH_RISCV_ZVE64D 1
+#endif
+#if defined(__riscv_v)
+#  define SIMDE_ARCH_RISCV_V 1
+#endif
+#if defined(__riscv_zvfh)
+#  define SIMDE_ARCH_RISCV_ZVFH 1
+#endif
+#if defined(__riscv_zvfhmin)
+#  define SIMDE_ARCH_RISCV_ZVFHMIN 1
 #endif
 
 /* SPARC

--- a/simde/simde-common.h
+++ b/simde/simde-common.h
@@ -1129,6 +1129,34 @@ HEDLEY_DIAGNOSTIC_POP
   #define SIMDE_CAST_VECTOR_SHIFT_COUNT(width, value) HEDLEY_STATIC_CAST(int##width##_t, (value))
 #endif
 
+/* Initial support for RISCV V extensions based on ZVE64D. */
+#if defined(SIMDE_ARCH_RISCV_ZVE64D) && SIMDE_NATURAL_VECTOR_SIZE >= 64 || 1
+  #define RVV_FIXED_TYPE_DEF(name, lmul) \
+    typedef vint8##name##_t  fixed_vint8##name##_t __attribute__((riscv_rvv_vector_bits(__riscv_v_fixed_vlen * lmul))); \
+    typedef vint16##name##_t fixed_vint16##name##_t __attribute__((riscv_rvv_vector_bits(__riscv_v_fixed_vlen * lmul))); \
+    typedef vint32##name##_t fixed_vint32##name##_t __attribute__((riscv_rvv_vector_bits(__riscv_v_fixed_vlen * lmul))); \
+    typedef vuint8##name##_t fixed_vuint8##name##_t __attribute__((riscv_rvv_vector_bits(__riscv_v_fixed_vlen * lmul))); \
+    typedef vuint16##name##_t fixed_vuint16##name##_t __attribute__((riscv_rvv_vector_bits(__riscv_v_fixed_vlen * lmul))); \
+    typedef vuint32##name##_t fixed_vuint32##name##_t __attribute__((riscv_rvv_vector_bits(__riscv_v_fixed_vlen * lmul))); \
+    typedef vfloat32##name##_t fixed_vfloat32##name##_t __attribute__((riscv_rvv_vector_bits(__riscv_v_fixed_vlen * lmul)));
+    RVV_FIXED_TYPE_DEF(mf2, 1/2);
+    RVV_FIXED_TYPE_DEF(m1, 1);
+    RVV_FIXED_TYPE_DEF(m2, 2);
+  #define RVV_FIXED_TYPE_DEF_64B(name, lmul) \
+    typedef vint64##name##_t fixed_vint64##name##_t __attribute__((riscv_rvv_vector_bits(__riscv_v_fixed_vlen * lmul))); \
+    typedef vuint64##name##_t fixed_vuint64##name##_t __attribute__((riscv_rvv_vector_bits(__riscv_v_fixed_vlen * lmul))); \
+    typedef vfloat64##name##_t fixed_vfloat64##name##_t __attribute__((riscv_rvv_vector_bits(__riscv_v_fixed_vlen * lmul)));
+    RVV_FIXED_TYPE_DEF_64B(m1, 1);
+    RVV_FIXED_TYPE_DEF_64B(m2, 2);
+  #if defined(SIMDE_ARCH_RISCV_ZVFH)
+    #define RVV_FIXED_TYPE_DEF_16F(name, lmul) \
+      typedef vfloat16##name##_t fixed_vfloat16##name##_t __attribute__((riscv_rvv_vector_bits(__riscv_v_fixed_vlen * lmul)));
+    RVV_FIXED_TYPE_DEF_16F(mf2, 1/2);
+    RVV_FIXED_TYPE_DEF_16F(m1, 1);
+    RVV_FIXED_TYPE_DEF_16F(m2, 2);
+  #endif
+#endif
+
 /* SIMDE_DIAGNOSTIC_DISABLE_USED_BUT_MARKED_UNUSED_ */
 HEDLEY_DIAGNOSTIC_POP
 

--- a/simde/simde-common.h
+++ b/simde/simde-common.h
@@ -1130,7 +1130,7 @@ HEDLEY_DIAGNOSTIC_POP
 #endif
 
 /* Initial support for RISCV V extensions based on ZVE64D. */
-#if defined(SIMDE_ARCH_RISCV_ZVE64D) && SIMDE_NATURAL_VECTOR_SIZE >= 64 || 1
+#if defined(SIMDE_ARCH_RISCV_ZVE64D) && SIMDE_NATURAL_VECTOR_SIZE >= 64
   #define RVV_FIXED_TYPE_DEF(name, lmul) \
     typedef vint8##name##_t  fixed_vint8##name##_t __attribute__((riscv_rvv_vector_bits(__riscv_v_fixed_vlen * lmul))); \
     typedef vint16##name##_t fixed_vint16##name##_t __attribute__((riscv_rvv_vector_bits(__riscv_v_fixed_vlen * lmul))); \

--- a/simde/simde-features.h
+++ b/simde/simde-features.h
@@ -375,6 +375,16 @@
   #endif
 #endif
 
+/*TODO: Support for other Zve* extensions ?*/
+#if !defined(SIMDE_RISCV_V_NATIVE) && !defined(SIMDE_RISCV_V_NO_NATIVE) && !defined(SIMDE_NO_NATIVE)
+  #if defined(SIMDE_ARCH_RISCV_ZVE64D)
+    #define SIMDE_RISCV_V_NATIVE
+  #endif
+#endif
+#if defined(SIMDE_RISCV_V_NATIVE)
+  #include <riscv_vector.h>
+#endif
+
 #if !defined(SIMDE_WASM_SIMD128_NATIVE) && !defined(SIMDE_WASM_SIMD128_NO_NATIVE) && !defined(SIMDE_NO_NATIVE)
   #if defined(SIMDE_ARCH_WASM_SIMD128)
     #define SIMDE_WASM_SIMD128_NATIVE
@@ -540,6 +550,8 @@
     #define SIMDE_NATURAL_FLOAT_VECTOR_SIZE (128)
     #define SIMDE_NATURAL_INT_VECTOR_SIZE (64)
     #define SIMDE_NATURAL_DOUBLE_VECTOR_SIZE (0)
+  #elif defined(SIMDE_RISCV_V_NATIVE) && defined(__riscv_v_fixed_vlen)
+        #define SIMDE_NATURAL_VECTOR_SIZE __riscv_v_fixed_vlen
   #endif
 
   #if !defined(SIMDE_NATURAL_VECTOR_SIZE)
@@ -679,6 +691,10 @@
 
   #if !defined(SIMDE_ARM_SVE_NATIVE)
     #define SIMDE_ARM_SVE_ENABLE_NATIVE_ALIASES
+  #endif
+
+  #if !defined(SIMDE_RISCV_V_NATIVE)
+    #define SIMDE_RISCV_V_ENABLE_NATIVE_ALIASES
   #endif
 
   #if !defined(SIMDE_MIPS_MSA_NATIVE)


### PR DESCRIPTION
- Modify simde-arch.h to detect RVV extension.
- Modify simde-features.h to include <riscv_vector.h> when using Zve64d-based architecture.
- Modify simde-common.h to declare fixed-length RVV types when using Zve64d-based architecture.
- Modify types.h to support the conversion from Neon types to RVV types.
- Modify add.h to implement the first Neon to RVV intrinsics conversion.