### PR TITLE
NEON: RVV intrinsics implementations, part1.

### DIFF
--- a/simde/arm/neon/ld1.h
+++ b/simde/arm/neon/ld1.h
@@ -43,7 +43,11 @@ simde_vld1_f16(simde_float16 const ptr[HEDLEY_ARRAY_PARAM(4)]) {
     return vld1_f16(ptr);
   #else
     simde_float16x4_private r_;
-    simde_memcpy(&r_, ptr, 8);
+    #if defined(SIMDE_RISCV_V_NATIVE) && SIMDE_ARCH_RISCV_ZVFH
+      r_.sv64 = __riscv_vle16_v_f16m1((_Float16 *)ptr , 4);
+    #else
+      simde_memcpy(&r_, ptr, 8);
+    #endif
     return simde_float16x4_from_private(r_);
   #endif
 }
@@ -59,7 +63,11 @@ simde_vld1_f32(simde_float32 const ptr[HEDLEY_ARRAY_PARAM(2)]) {
     return vld1_f32(ptr);
   #else
     simde_float32x2_private r_;
-    simde_memcpy(&r_, ptr, 8);
+    #if defined(SIMDE_RISCV_V_NATIVE)
+      r_.sv64 = __riscv_vle32_v_f32m1(ptr , 2);
+    #else
+      simde_memcpy(&r_, ptr, 8);
+    #endif
     return simde_float32x2_from_private(r_);
   #endif
 }
@@ -75,7 +83,11 @@ simde_vld1_f64(simde_float64 const ptr[HEDLEY_ARRAY_PARAM(1)]) {
     return vld1_f64(ptr);
   #else
     simde_float64x1_private r_;
-    simde_memcpy(&r_, ptr, 8);
+    #if defined(SIMDE_RISCV_V_NATIVE)
+      r_.sv64 = __riscv_vle64_v_f64m1(ptr , 1);
+    #else
+      simde_memcpy(&r_, ptr, 8);
+    #endif
     return simde_float64x1_from_private(r_);
   #endif
 }
@@ -91,7 +103,11 @@ simde_vld1_s8(int8_t const ptr[HEDLEY_ARRAY_PARAM(8)]) {
     return vld1_s8(ptr);
   #else
     simde_int8x8_private r_;
-    simde_memcpy(&r_, ptr, 8);
+    #if defined(SIMDE_RISCV_V_NATIVE)
+      r_.sv64 = __riscv_vle8_v_i8m1(ptr , 8);
+    #else
+      simde_memcpy(&r_, ptr, 8);
+    #endif
     return simde_int8x8_from_private(r_);
   #endif
 }
@@ -107,7 +123,11 @@ simde_vld1_s16(int16_t const ptr[HEDLEY_ARRAY_PARAM(4)]) {
     return vld1_s16(ptr);
   #else
     simde_int16x4_private r_;
-    simde_memcpy(&r_, ptr, 8);
+    #if defined(SIMDE_RISCV_V_NATIVE)
+      r_.sv64 = __riscv_vle16_v_i16m1(ptr , 4);
+    #else
+      simde_memcpy(&r_, ptr, 8);
+    #endif
     return simde_int16x4_from_private(r_);
   #endif
 }
@@ -123,7 +143,11 @@ simde_vld1_s32(int32_t const ptr[HEDLEY_ARRAY_PARAM(2)]) {
     return vld1_s32(ptr);
   #else
     simde_int32x2_private r_;
-    simde_memcpy(&r_, ptr, 8);
+    #if defined(SIMDE_RISCV_V_NATIVE)
+      r_.sv64 = __riscv_vle32_v_i32m1(ptr , 2);
+    #else
+      simde_memcpy(&r_, ptr, 8);
+    #endif
     return simde_int32x2_from_private(r_);
   #endif
 }
@@ -139,7 +163,11 @@ simde_vld1_s64(int64_t const ptr[HEDLEY_ARRAY_PARAM(1)]) {
     return vld1_s64(ptr);
   #else
     simde_int64x1_private r_;
-    simde_memcpy(&r_, ptr, 8);
+    #if defined(SIMDE_RISCV_V_NATIVE)
+      r_.sv64 = __riscv_vle64_v_i64m1(ptr , 1);
+    #else
+      simde_memcpy(&r_, ptr, 8);
+    #endif
     return simde_int64x1_from_private(r_);
   #endif
 }
@@ -155,7 +183,11 @@ simde_vld1_u8(uint8_t const ptr[HEDLEY_ARRAY_PARAM(8)]) {
     return vld1_u8(ptr);
   #else
     simde_uint8x8_private r_;
-    simde_memcpy(&r_, ptr, 8);
+    #if defined(SIMDE_RISCV_V_NATIVE)
+      r_.sv64 = __riscv_vle8_v_u8m1(ptr , 8);
+    #else
+      simde_memcpy(&r_, ptr, 8);
+    #endif
     return simde_uint8x8_from_private(r_);
   #endif
 }
@@ -171,7 +203,11 @@ simde_vld1_u16(uint16_t const ptr[HEDLEY_ARRAY_PARAM(4)]) {
     return vld1_u16(ptr);
   #else
     simde_uint16x4_private r_;
-    simde_memcpy(&r_, ptr, 8);
+    #if defined(SIMDE_RISCV_V_NATIVE)
+      r_.sv64 = __riscv_vle16_v_u16m1(ptr , 4);
+    #else
+      simde_memcpy(&r_, ptr, 8);
+    #endif
     return simde_uint16x4_from_private(r_);
   #endif
 }
@@ -187,7 +223,11 @@ simde_vld1_u32(uint32_t const ptr[HEDLEY_ARRAY_PARAM(2)]) {
     return vld1_u32(ptr);
   #else
     simde_uint32x2_private r_;
-    simde_memcpy(&r_, ptr, 8);
+    #if defined(SIMDE_RISCV_V_NATIVE)
+      r_.sv64 = __riscv_vle32_v_u32m1(ptr , 2);
+    #else
+      simde_memcpy(&r_, ptr, 8);
+    #endif
     return simde_uint32x2_from_private(r_);
   #endif
 }
@@ -203,7 +243,11 @@ simde_vld1_u64(uint64_t const ptr[HEDLEY_ARRAY_PARAM(1)]) {
     return vld1_u64(ptr);
   #else
     simde_uint64x1_private r_;
-    simde_memcpy(&r_, ptr, 8);
+    #if defined(SIMDE_RISCV_V_NATIVE)
+      r_.sv64 = __riscv_vle64_v_u64m1(ptr , 1);
+    #else
+      simde_memcpy(&r_, ptr, 8);
+    #endif
     return simde_uint64x1_from_private(r_);
   #endif
 }
@@ -221,6 +265,8 @@ simde_vld1q_f16(simde_float16 const ptr[HEDLEY_ARRAY_PARAM(8)]) {
     simde_float16x8_private r_;
     #if defined(SIMDE_WASM_SIMD128_NATIVE)
       r_.v128 = wasm_v128_load(ptr);
+    #elif defined(SIMDE_RISCV_V_NATIVE) && SIMDE_ARCH_RISCV_ZVFH
+      r_.sv128 = __riscv_vle16_v_f16m1((_Float16 *)ptr , 8);
     #else
       simde_memcpy(&r_, ptr, 16);
     #endif
@@ -241,6 +287,8 @@ simde_vld1q_f32(simde_float32 const ptr[HEDLEY_ARRAY_PARAM(4)]) {
     simde_float32x4_private r_;
     #if defined(SIMDE_WASM_SIMD128_NATIVE)
       r_.v128 = wasm_v128_load(ptr);
+    #elif defined(SIMDE_RISCV_V_NATIVE)
+      r_.sv128 = __riscv_vle32_v_f32m1(ptr , 4);
     #else
       simde_memcpy(&r_, ptr, 16);
     #endif
@@ -261,6 +309,8 @@ simde_vld1q_f64(simde_float64 const ptr[HEDLEY_ARRAY_PARAM(2)]) {
     simde_float64x2_private r_;
     #if defined(SIMDE_WASM_SIMD128_NATIVE)
       r_.v128 = wasm_v128_load(ptr);
+    #elif defined(SIMDE_RISCV_V_NATIVE)
+      r_.sv128 = __riscv_vle64_v_f64m1(ptr , 2);
     #else
       simde_memcpy(&r_, ptr, 16);
     #endif
@@ -281,6 +331,8 @@ simde_vld1q_s8(int8_t const ptr[HEDLEY_ARRAY_PARAM(16)]) {
     simde_int8x16_private r_;
     #if defined(SIMDE_WASM_SIMD128_NATIVE)
       r_.v128 = wasm_v128_load(ptr);
+    #elif defined(SIMDE_RISCV_V_NATIVE)
+      r_.sv128 = __riscv_vle8_v_i8m1(ptr , 16);
     #else
       simde_memcpy(&r_, ptr, 16);
     #endif
@@ -301,6 +353,8 @@ simde_vld1q_s16(int16_t const ptr[HEDLEY_ARRAY_PARAM(8)]) {
     simde_int16x8_private r_;
     #if defined(SIMDE_WASM_SIMD128_NATIVE)
       r_.v128 = wasm_v128_load(ptr);
+    #elif defined(SIMDE_RISCV_V_NATIVE)
+      r_.sv128 = __riscv_vle16_v_i16m1(ptr , 8);
     #else
       simde_memcpy(&r_, ptr, 16);
     #endif
@@ -321,6 +375,8 @@ simde_vld1q_s32(int32_t const ptr[HEDLEY_ARRAY_PARAM(4)]) {
     simde_int32x4_private r_;
     #if defined(SIMDE_WASM_SIMD128_NATIVE)
       r_.v128 = wasm_v128_load(ptr);
+    #elif defined(SIMDE_RISCV_V_NATIVE)
+      r_.sv128 = __riscv_vle32_v_i32m1(ptr , 4);
     #else
       simde_memcpy(&r_, ptr, 16);
     #endif
@@ -341,6 +397,8 @@ simde_vld1q_s64(int64_t const ptr[HEDLEY_ARRAY_PARAM(2)]) {
     simde_int64x2_private r_;
     #if defined(SIMDE_WASM_SIMD128_NATIVE)
       r_.v128 = wasm_v128_load(ptr);
+    #elif defined(SIMDE_RISCV_V_NATIVE)
+      r_.sv128 = __riscv_vle64_v_i64m1(ptr , 2);
     #else
       simde_memcpy(&r_, ptr, 16);
     #endif
@@ -361,6 +419,8 @@ simde_vld1q_u8(uint8_t const ptr[HEDLEY_ARRAY_PARAM(16)]) {
     simde_uint8x16_private r_;
     #if defined(SIMDE_WASM_SIMD128_NATIVE)
       r_.v128 = wasm_v128_load(ptr);
+    #elif defined(SIMDE_RISCV_V_NATIVE)
+      r_.sv128 = __riscv_vle8_v_u8m1(ptr , 16);
     #else
       simde_memcpy(&r_, ptr, 16);
     #endif
@@ -381,6 +441,8 @@ simde_vld1q_u16(uint16_t const ptr[HEDLEY_ARRAY_PARAM(8)]) {
     simde_uint16x8_private r_;
     #if defined(SIMDE_WASM_SIMD128_NATIVE)
       r_.v128 = wasm_v128_load(ptr);
+    #elif defined(SIMDE_RISCV_V_NATIVE)
+      r_.sv128 = __riscv_vle16_v_u16m1(ptr , 8);
     #else
       simde_memcpy(&r_, ptr, 16);
     #endif
@@ -401,6 +463,8 @@ simde_vld1q_u32(uint32_t const ptr[HEDLEY_ARRAY_PARAM(4)]) {
     simde_uint32x4_private r_;
     #if defined(SIMDE_WASM_SIMD128_NATIVE)
       r_.v128 = wasm_v128_load(ptr);
+    #elif defined(SIMDE_RISCV_V_NATIVE)
+      r_.sv128 = __riscv_vle32_v_u32m1(ptr , 4);
     #else
       simde_memcpy(&r_, ptr, 16);
     #endif
@@ -421,6 +485,8 @@ simde_vld1q_u64(uint64_t const ptr[HEDLEY_ARRAY_PARAM(2)]) {
     simde_uint64x2_private r_;
     #if defined(SIMDE_WASM_SIMD128_NATIVE)
       r_.v128 = wasm_v128_load(ptr);
+    #elif defined(SIMDE_RISCV_V_NATIVE)
+      r_.sv128 = __riscv_vle64_v_u64m1(ptr , 2);
     #else
       simde_memcpy(&r_, ptr, 16);
     #endif

--- a/simde/arm/neon/ld1_x2.h
+++ b/simde/arm/neon/ld1_x2.h
@@ -25,6 +25,7 @@
  *   2021      Zhi An Ng <zhin@google.com> (Copyright owned by Google, LLC)
  *   2021      Décio Luiz Gazzoni Filho <decio@decpp.net>
  *   2023      Yi-Yen Chung <eric681@andestech.com> (Copyright owned by Andes Technology)
+ *   2023      Chi-Wei Chu <wewe5215@gapp.nthu.edu.tw>
  */
 
 #if !defined(SIMDE_ARM_NEON_LD1_X2_H)
@@ -51,9 +52,14 @@ simde_vld1_f16_x2(simde_float16 const ptr[HEDLEY_ARRAY_PARAM(8)]) {
     return vld1_f16_x2(ptr);
   #else
     simde_float16x4_private a_[2];
-    for (size_t i = 0; i < 8; i++) {
-      a_[i / 4].values[i % 4] = ptr[i];
-    }
+    #if defined(SIMDE_RISCV_V_NATIVE) && SIMDE_ARCH_RISCV_ZVFH
+      a_[0].sv64 = __riscv_vle16_v_f16m1((_Float16 *)ptr , 4);
+      a_[1].sv64 = __riscv_vle16_v_f16m1((_Float16 *)(ptr+4) , 4);
+    #else
+      for (size_t i = 0; i < 8; i++) {
+        a_[i / 4].values[i % 4] = ptr[i];
+      }
+    #endif
     simde_float16x4x2_t s_ = { { simde_float16x4_from_private(a_[0]),
                                  simde_float16x4_from_private(a_[1]) } };
     return s_;
@@ -74,9 +80,14 @@ simde_vld1_f32_x2(simde_float32 const ptr[HEDLEY_ARRAY_PARAM(4)]) {
     return vld1_f32_x2(ptr);
   #else
     simde_float32x2_private a_[2];
-    for (size_t i = 0; i < 4; i++) {
-      a_[i / 2].values[i % 2] = ptr[i];
-    }
+    #if defined(SIMDE_RISCV_V_NATIVE)
+      a_[0].sv64 = __riscv_vle32_v_f32m1(ptr , 2);
+      a_[1].sv64 = __riscv_vle32_v_f32m1(ptr+2 , 2);
+    #else
+      for (size_t i = 0; i < 4; i++) {
+        a_[i / 2].values[i % 2] = ptr[i];
+      }
+    #endif
     simde_float32x2x2_t s_ = { { simde_float32x2_from_private(a_[0]),
                                  simde_float32x2_from_private(a_[1]) } };
     return s_;
@@ -97,9 +108,14 @@ simde_vld1_f64_x2(simde_float64 const ptr[HEDLEY_ARRAY_PARAM(2)]) {
     return vld1_f64_x2(ptr);
   #else
     simde_float64x1_private a_[2];
-    for (size_t i = 0; i < 2; i++) {
-      a_[i].values[0] = ptr[i];
-    }
+    #if defined(SIMDE_RISCV_V_NATIVE)
+      a_[0].sv64 = __riscv_vle64_v_f64m1(ptr , 1);
+      a_[1].sv64 = __riscv_vle64_v_f64m1(ptr+1 , 1);
+    #else
+      for (size_t i = 0; i < 2; i++) {
+        a_[i].values[0] = ptr[i];
+      }
+    #endif
     simde_float64x1x2_t s_ = { { simde_float64x1_from_private(a_[0]),
                                  simde_float64x1_from_private(a_[1]) } };
     return s_;
@@ -120,9 +136,14 @@ simde_vld1_s8_x2(int8_t const ptr[HEDLEY_ARRAY_PARAM(16)]) {
     return vld1_s8_x2(ptr);
   #else
     simde_int8x8_private a_[2];
-    for (size_t i = 0; i < 16; i++) {
-      a_[i / 8].values[i % 8] = ptr[i];
-    }
+    #if defined(SIMDE_RISCV_V_NATIVE)
+      a_[0].sv64 = __riscv_vle8_v_i8m1(ptr , 8);
+      a_[1].sv64 = __riscv_vle8_v_i8m1(ptr+8 , 8);
+    #else
+      for (size_t i = 0; i < 16; i++) {
+        a_[i / 8].values[i % 8] = ptr[i];
+      }
+    #endif
     simde_int8x8x2_t s_ = { { simde_int8x8_from_private(a_[0]),
                               simde_int8x8_from_private(a_[1]) } };
     return s_;
@@ -143,9 +164,14 @@ simde_vld1_s16_x2(int16_t const ptr[HEDLEY_ARRAY_PARAM(8)]) {
     return vld1_s16_x2(ptr);
   #else
     simde_int16x4_private a_[2];
-    for (size_t i = 0; i < 8; i++) {
-      a_[i / 4].values[i % 4] = ptr[i];
-    }
+    #if defined(SIMDE_RISCV_V_NATIVE)
+      a_[0].sv64 = __riscv_vle16_v_i16m1(ptr , 4);
+      a_[1].sv64 = __riscv_vle16_v_i16m1(ptr+4 , 4);
+    #else
+      for (size_t i = 0; i < 8; i++) {
+        a_[i / 4].values[i % 4] = ptr[i];
+      }
+    #endif
     simde_int16x4x2_t s_ = { { simde_int16x4_from_private(a_[0]),
                                simde_int16x4_from_private(a_[1]) } };
     return s_;
@@ -166,9 +192,14 @@ simde_vld1_s32_x2(int32_t const ptr[HEDLEY_ARRAY_PARAM(4)]) {
     return vld1_s32_x2(ptr);
   #else
     simde_int32x2_private a_[2];
-    for (size_t i = 0; i < 4; i++) {
-      a_[i / 2].values[i % 2] = ptr[i];
-    }
+    #if defined(SIMDE_RISCV_V_NATIVE)
+      a_[0].sv64 = __riscv_vle32_v_i32m1(ptr , 2);
+      a_[1].sv64 = __riscv_vle32_v_i32m1(ptr+2 , 2);
+    #else
+      for (size_t i = 0; i < 4; i++) {
+        a_[i / 2].values[i % 2] = ptr[i];
+      }
+    #endif
     simde_int32x2x2_t s_ = { { simde_int32x2_from_private(a_[0]),
                                simde_int32x2_from_private(a_[1]) } };
     return s_;
@@ -189,9 +220,14 @@ simde_vld1_s64_x2(int64_t const ptr[HEDLEY_ARRAY_PARAM(2)]) {
     return vld1_s64_x2(ptr);
   #else
     simde_int64x1_private a_[2];
-    for (size_t i = 0; i < 2; i++) {
-      a_[i].values[0] = ptr[i];
-    }
+    #if defined(SIMDE_RISCV_V_NATIVE)
+      a_[0].sv64 = __riscv_vle64_v_i64m1(ptr , 1);
+      a_[1].sv64 = __riscv_vle64_v_i64m1(ptr+1 , 1);
+    #else
+      for (size_t i = 0; i < 2; i++) {
+        a_[i].values[0] = ptr[i];
+      }
+    #endif
     simde_int64x1x2_t s_ = { { simde_int64x1_from_private(a_[0]),
                                simde_int64x1_from_private(a_[1]) } };
     return s_;
@@ -212,9 +248,14 @@ simde_vld1_u8_x2(uint8_t const ptr[HEDLEY_ARRAY_PARAM(16)]) {
     return vld1_u8_x2(ptr);
   #else
     simde_uint8x8_private a_[2];
-    for (size_t i = 0; i < 16; i++) {
-      a_[i / 8].values[i % 8] = ptr[i];
-    }
+    #if defined(SIMDE_RISCV_V_NATIVE)
+      a_[0].sv64 = __riscv_vle8_v_u8m1(ptr , 8);
+      a_[1].sv64 = __riscv_vle8_v_u8m1(ptr+8 , 8);
+    #else
+      for (size_t i = 0; i < 16; i++) {
+        a_[i / 8].values[i % 8] = ptr[i];
+      }
+    #endif
     simde_uint8x8x2_t s_ = { { simde_uint8x8_from_private(a_[0]),
                                simde_uint8x8_from_private(a_[1]) } };
     return s_;
@@ -235,9 +276,14 @@ simde_vld1_u16_x2(uint16_t const ptr[HEDLEY_ARRAY_PARAM(8)]) {
     return vld1_u16_x2(ptr);
   #else
     simde_uint16x4_private a_[2];
-    for (size_t i = 0; i < 8; i++) {
-      a_[i / 4].values[i % 4] = ptr[i];
-    }
+    #if defined(SIMDE_RISCV_V_NATIVE)
+      a_[0].sv64 = __riscv_vle16_v_u16m1(ptr , 4);
+      a_[1].sv64 = __riscv_vle16_v_u16m1(ptr+4 , 4);
+    #else
+      for (size_t i = 0; i < 8; i++) {
+        a_[i / 4].values[i % 4] = ptr[i];
+      }
+    #endif
     simde_uint16x4x2_t s_ = { { simde_uint16x4_from_private(a_[0]),
                                 simde_uint16x4_from_private(a_[1]) } };
     return s_;
@@ -258,9 +304,14 @@ simde_vld1_u32_x2(uint32_t const ptr[HEDLEY_ARRAY_PARAM(4)]) {
     return vld1_u32_x2(ptr);
   #else
     simde_uint32x2_private a_[2];
-    for (size_t i = 0; i < 4; i++) {
-      a_[i / 2].values[i % 2] = ptr[i];
-    }
+    #if defined(SIMDE_RISCV_V_NATIVE)
+      a_[0].sv64 = __riscv_vle32_v_u32m1(ptr , 2);
+      a_[1].sv64 = __riscv_vle32_v_u32m1(ptr+2 , 2);
+    #else
+      for (size_t i = 0; i < 4; i++) {
+        a_[i / 2].values[i % 2] = ptr[i];
+      }
+    #endif
     simde_uint32x2x2_t s_ = { { simde_uint32x2_from_private(a_[0]),
                                 simde_uint32x2_from_private(a_[1]) } };
     return s_;
@@ -281,9 +332,14 @@ simde_vld1_u64_x2(uint64_t const ptr[HEDLEY_ARRAY_PARAM(2)]) {
     return vld1_u64_x2(ptr);
   #else
     simde_uint64x1_private a_[2];
-    for (size_t i = 0; i < 2; i++) {
-      a_[i].values[0] = ptr[i];
-    }
+    #if defined(SIMDE_RISCV_V_NATIVE)
+      a_[0].sv64 = __riscv_vle64_v_u64m1(ptr , 1);
+      a_[1].sv64 = __riscv_vle64_v_u64m1(ptr+1 , 1);
+    #else
+      for (size_t i = 0; i < 2; i++) {
+        a_[i].values[0] = ptr[i];
+      }
+    #endif
     simde_uint64x1x2_t s_ = { { simde_uint64x1_from_private(a_[0]),
                                 simde_uint64x1_from_private(a_[1]) } };
     return s_;

--- a/simde/arm/neon/ld1_x3.h
+++ b/simde/arm/neon/ld1_x3.h
@@ -24,6 +24,7 @@
  *   2020      Evan Nemerson <evan@nemerson.com>
  *   2021      Zhi An Ng <zhin@google.com> (Copyright owned by Google, LLC)
  *   2023      Yi-Yen Chung <eric681@andestech.com> (Copyright owned by Andes Technology)
+ *   2023      Chi-Wei Chu <wewe5215@gapp.nthu.edu.tw>
  */
 
 #if !defined(SIMDE_ARM_NEON_LD1_X3_H)
@@ -50,9 +51,15 @@ simde_vld1_f16_x3(simde_float16 const ptr[HEDLEY_ARRAY_PARAM(12)]) {
     return vld1_f16_x3(ptr);
   #else
     simde_float16x4_private a_[3];
-    for (size_t i = 0; i < 12; i++) {
-      a_[i / 4].values[i % 4] = ptr[i];
-    }
+    #if defined(SIMDE_RISCV_V_NATIVE) && SIMDE_ARCH_RISCV_ZVFH
+      a_[0].sv64 = __riscv_vle16_v_f16m1((_Float16 *)ptr , 4);
+      a_[1].sv64 = __riscv_vle16_v_f16m1((_Float16 *)(ptr+4) , 4);
+      a_[2].sv64 = __riscv_vle16_v_f16m1((_Float16 *)(ptr+8) , 4);
+    #else
+      for (size_t i = 0; i < 12; i++) {
+        a_[i / 4].values[i % 4] = ptr[i];
+      }
+    #endif
     simde_float16x4x3_t s_ = { { simde_float16x4_from_private(a_[0]),
                                  simde_float16x4_from_private(a_[1]),
                                  simde_float16x4_from_private(a_[2]) } };
@@ -74,9 +81,15 @@ simde_vld1_f32_x3(simde_float32 const ptr[HEDLEY_ARRAY_PARAM(6)]) {
     return vld1_f32_x3(ptr);
   #else
     simde_float32x2_private a_[3];
-    for (size_t i = 0; i < 6; i++) {
-      a_[i / 2].values[i % 2] = ptr[i];
-    }
+    #if defined(SIMDE_RISCV_V_NATIVE)
+      a_[0].sv64 = __riscv_vle32_v_f32m1(ptr , 2);
+      a_[1].sv64 = __riscv_vle32_v_f32m1(ptr+2 , 2);
+      a_[2].sv64 = __riscv_vle32_v_f32m1(ptr+4 , 2);
+    #else
+      for (size_t i = 0; i < 6; i++) {
+        a_[i / 2].values[i % 2] = ptr[i];
+      }
+    #endif
     simde_float32x2x3_t s_ = { { simde_float32x2_from_private(a_[0]),
                                  simde_float32x2_from_private(a_[1]),
                                  simde_float32x2_from_private(a_[2]) } };
@@ -98,9 +111,15 @@ simde_vld1_f64_x3(simde_float64 const ptr[HEDLEY_ARRAY_PARAM(3)]) {
     return vld1_f64_x3(ptr);
   #else
     simde_float64x1_private a_[3];
-    for (size_t i = 0; i < 3; i++) {
-      a_[i].values[0] = ptr[i];
-    }
+    #if defined(SIMDE_RISCV_V_NATIVE)
+      a_[0].sv64 = __riscv_vle64_v_f64m1(ptr , 1);
+      a_[1].sv64 = __riscv_vle64_v_f64m1(ptr+1 , 1);
+      a_[2].sv64 = __riscv_vle64_v_f64m1(ptr+2 , 1);
+    #else
+      for (size_t i = 0; i < 3; i++) {
+        a_[i].values[0] = ptr[i];
+      }
+    #endif
     simde_float64x1x3_t s_ = { { simde_float64x1_from_private(a_[0]),
                                  simde_float64x1_from_private(a_[1]),
                                  simde_float64x1_from_private(a_[2]) } };
@@ -122,9 +141,15 @@ simde_vld1_s8_x3(int8_t const ptr[HEDLEY_ARRAY_PARAM(24)]) {
     return vld1_s8_x3(ptr);
   #else
     simde_int8x8_private a_[3];
-    for (size_t i = 0; i < 24; i++) {
-      a_[i / 8].values[i % 8] = ptr[i];
-    }
+    #if defined(SIMDE_RISCV_V_NATIVE)
+      a_[0].sv64 = __riscv_vle8_v_i8m1(ptr , 8);
+      a_[1].sv64 = __riscv_vle8_v_i8m1(ptr+8 , 8);
+      a_[2].sv64 = __riscv_vle8_v_i8m1(ptr+16 , 8);
+    #else
+      for (size_t i = 0; i < 24; i++) {
+        a_[i / 8].values[i % 8] = ptr[i];
+      }
+    #endif
     simde_int8x8x3_t s_ = { { simde_int8x8_from_private(a_[0]),
                               simde_int8x8_from_private(a_[1]),
                               simde_int8x8_from_private(a_[2]) } };
@@ -146,9 +171,15 @@ simde_vld1_s16_x3(int16_t const ptr[HEDLEY_ARRAY_PARAM(12)]) {
     return vld1_s16_x3(ptr);
   #else
     simde_int16x4_private a_[3];
-    for (size_t i = 0; i < 12; i++) {
-      a_[i / 4].values[i % 4] = ptr[i];
-    }
+    #if defined(SIMDE_RISCV_V_NATIVE)
+      a_[0].sv64 = __riscv_vle16_v_i16m1(ptr , 4);
+      a_[1].sv64 = __riscv_vle16_v_i16m1(ptr+4 , 4);
+      a_[2].sv64 = __riscv_vle16_v_i16m1(ptr+8 , 4);
+    #else
+      for (size_t i = 0; i < 12; i++) {
+        a_[i / 4].values[i % 4] = ptr[i];
+      }
+    #endif
     simde_int16x4x3_t s_ = { { simde_int16x4_from_private(a_[0]),
                                simde_int16x4_from_private(a_[1]),
                                simde_int16x4_from_private(a_[2]) } };
@@ -170,9 +201,15 @@ simde_vld1_s32_x3(int32_t const ptr[HEDLEY_ARRAY_PARAM(6)]) {
     return vld1_s32_x3(ptr);
   #else
     simde_int32x2_private a_[3];
-    for (size_t i = 0; i < 6; i++) {
-      a_[i / 2].values[i % 2] = ptr[i];
-    }
+    #if defined(SIMDE_RISCV_V_NATIVE)
+      a_[0].sv64 = __riscv_vle32_v_i32m1(ptr , 2);
+      a_[1].sv64 = __riscv_vle32_v_i32m1(ptr+2 , 2);
+      a_[2].sv64 = __riscv_vle32_v_i32m1(ptr+4 , 2);
+    #else
+      for (size_t i = 0; i < 6; i++) {
+        a_[i / 2].values[i % 2] = ptr[i];
+      }
+    #endif
     simde_int32x2x3_t s_ = { { simde_int32x2_from_private(a_[0]),
                                simde_int32x2_from_private(a_[1]),
                                simde_int32x2_from_private(a_[2]) } };
@@ -194,9 +231,15 @@ simde_vld1_s64_x3(int64_t const ptr[HEDLEY_ARRAY_PARAM(3)]) {
     return vld1_s64_x3(ptr);
   #else
     simde_int64x1_private a_[3];
-    for (size_t i = 0; i < 3; i++) {
-      a_[i].values[0] = ptr[i];
-    }
+    #if defined(SIMDE_RISCV_V_NATIVE)
+      a_[0].sv64 = __riscv_vle64_v_i64m1(ptr , 1);
+      a_[1].sv64 = __riscv_vle64_v_i64m1(ptr+1 , 1);
+      a_[2].sv64 = __riscv_vle64_v_i64m1(ptr+2 , 1);
+    #else
+      for (size_t i = 0; i < 3; i++) {
+        a_[i].values[0] = ptr[i];
+      }
+    #endif
     simde_int64x1x3_t s_ = { { simde_int64x1_from_private(a_[0]),
                                simde_int64x1_from_private(a_[1]),
                                simde_int64x1_from_private(a_[2]) } };
@@ -218,9 +261,15 @@ simde_vld1_u8_x3(uint8_t const ptr[HEDLEY_ARRAY_PARAM(24)]) {
     return vld1_u8_x3(ptr);
   #else
     simde_uint8x8_private a_[3];
-    for (size_t i = 0; i < 24; i++) {
-      a_[i / 8].values[i % 8] = ptr[i];
-    }
+    #if defined(SIMDE_RISCV_V_NATIVE)
+      a_[0].sv64 = __riscv_vle8_v_u8m1(ptr , 8);
+      a_[1].sv64 = __riscv_vle8_v_u8m1(ptr+8 , 8);
+      a_[2].sv64 = __riscv_vle8_v_u8m1(ptr+16 , 8);
+    #else
+      for (size_t i = 0; i < 24; i++) {
+        a_[i / 8].values[i % 8] = ptr[i];
+      }
+    #endif
     simde_uint8x8x3_t s_ = { { simde_uint8x8_from_private(a_[0]),
                                simde_uint8x8_from_private(a_[1]),
                                simde_uint8x8_from_private(a_[2]) } };
@@ -242,9 +291,15 @@ simde_vld1_u16_x3(uint16_t const ptr[HEDLEY_ARRAY_PARAM(12)]) {
     return vld1_u16_x3(ptr);
   #else
     simde_uint16x4_private a_[3];
-    for (size_t i = 0; i < 12; i++) {
-      a_[i / 4].values[i % 4] = ptr[i];
-    }
+    #if defined(SIMDE_RISCV_V_NATIVE)
+      a_[0].sv64 = __riscv_vle16_v_u16m1(ptr , 4);
+      a_[1].sv64 = __riscv_vle16_v_u16m1(ptr+4 , 4);
+      a_[2].sv64 = __riscv_vle16_v_u16m1(ptr+8 , 4);
+    #else
+      for (size_t i = 0; i < 12; i++) {
+        a_[i / 4].values[i % 4] = ptr[i];
+      }
+    #endif
     simde_uint16x4x3_t s_ = { { simde_uint16x4_from_private(a_[0]),
                                 simde_uint16x4_from_private(a_[1]),
                                 simde_uint16x4_from_private(a_[2]) } };
@@ -266,9 +321,15 @@ simde_vld1_u32_x3(uint32_t const ptr[HEDLEY_ARRAY_PARAM(6)]) {
     return vld1_u32_x3(ptr);
   #else
     simde_uint32x2_private a_[3];
-    for (size_t i = 0; i < 6; i++) {
-      a_[i / 2].values[i % 2] = ptr[i];
-    }
+    #if defined(SIMDE_RISCV_V_NATIVE)
+      a_[0].sv64 = __riscv_vle32_v_u32m1(ptr , 2);
+      a_[1].sv64 = __riscv_vle32_v_u32m1(ptr+2 , 2);
+      a_[2].sv64 = __riscv_vle32_v_u32m1(ptr+4 , 2);
+    #else
+      for (size_t i = 0; i < 6; i++) {
+        a_[i / 2].values[i % 2] = ptr[i];
+      }
+    #endif
     simde_uint32x2x3_t s_ = { { simde_uint32x2_from_private(a_[0]),
                                 simde_uint32x2_from_private(a_[1]),
                                 simde_uint32x2_from_private(a_[2]) } };
@@ -290,9 +351,15 @@ simde_vld1_u64_x3(uint64_t const ptr[HEDLEY_ARRAY_PARAM(3)]) {
     return vld1_u64_x3(ptr);
   #else
     simde_uint64x1_private a_[3];
-    for (size_t i = 0; i < 3; i++) {
-      a_[i].values[0] = ptr[i];
-    }
+    #if defined(SIMDE_RISCV_V_NATIVE)
+      a_[0].sv64 = __riscv_vle64_v_u64m1(ptr , 1);
+      a_[1].sv64 = __riscv_vle64_v_u64m1(ptr+1 , 1);
+      a_[2].sv64 = __riscv_vle64_v_u64m1(ptr+2 , 1);
+    #else
+      for (size_t i = 0; i < 3; i++) {
+        a_[i].values[0] = ptr[i];
+      }
+    #endif
     simde_uint64x1x3_t s_ = { { simde_uint64x1_from_private(a_[0]),
                                 simde_uint64x1_from_private(a_[1]),
                                 simde_uint64x1_from_private(a_[2]) } };

--- a/simde/arm/neon/ld1_x4.h
+++ b/simde/arm/neon/ld1_x4.h
@@ -25,6 +25,7 @@
  *   2021      Zhi An Ng <zhin@google.com> (Copyright owned by Google, LLC)
  *   2021      Décio Luiz Gazzoni Filho <decio@decpp.net>
  *   2023      Yi-Yen Chung <eric681@andestech.com> (Copyright owned by Andes Technology)
+ *   2023      Chi-Wei Chu <wewe5215@gapp.nthu.edu.tw>
  */
 
 #if !defined(SIMDE_ARM_NEON_LD1_X4_H)
@@ -51,9 +52,16 @@ simde_vld1_f16_x4(simde_float16 const ptr[HEDLEY_ARRAY_PARAM(16)]) {
     return vld1_f16_x4(ptr);
   #else
     simde_float16x4_private a_[4];
-    for (size_t i = 0; i < 16; i++) {
-      a_[i / 4].values[i % 4] = ptr[i];
-    }
+    #if defined(SIMDE_RISCV_V_NATIVE) && SIMDE_ARCH_RISCV_ZVFH
+      a_[0].sv64 = __riscv_vle16_v_f16m1((_Float16 *)ptr , 4);
+      a_[1].sv64 = __riscv_vle16_v_f16m1((_Float16 *)(ptr+4) , 4);
+      a_[2].sv64 = __riscv_vle16_v_f16m1((_Float16 *)(ptr+8) , 4);
+      a_[3].sv64 = __riscv_vle16_v_f16m1((_Float16 *)(ptr+12) , 4);
+    #else
+      for (size_t i = 0; i < 16; i++) {
+        a_[i / 4].values[i % 4] = ptr[i];
+      }
+    #endif
     simde_float16x4x4_t s_ = { { simde_float16x4_from_private(a_[0]),
                                  simde_float16x4_from_private(a_[1]),
                                  simde_float16x4_from_private(a_[2]),
@@ -76,9 +84,16 @@ simde_vld1_f32_x4(simde_float32 const ptr[HEDLEY_ARRAY_PARAM(8)]) {
     return vld1_f32_x4(ptr);
   #else
     simde_float32x2_private a_[4];
-    for (size_t i = 0; i < 8; i++) {
-      a_[i / 2].values[i % 2] = ptr[i];
-    }
+    #if defined(SIMDE_RISCV_V_NATIVE)
+      a_[0].sv64 = __riscv_vle32_v_f32m1(ptr , 2);
+      a_[1].sv64 = __riscv_vle32_v_f32m1(ptr+2 , 2);
+      a_[2].sv64 = __riscv_vle32_v_f32m1(ptr+4 , 2);
+      a_[3].sv64 = __riscv_vle32_v_f32m1(ptr+6 , 2);
+    #else
+      for (size_t i = 0; i < 8; i++) {
+        a_[i / 2].values[i % 2] = ptr[i];
+      }
+    #endif
     simde_float32x2x4_t s_ = { { simde_float32x2_from_private(a_[0]),
                                  simde_float32x2_from_private(a_[1]),
                                  simde_float32x2_from_private(a_[2]),
@@ -101,9 +116,16 @@ simde_vld1_f64_x4(simde_float64 const ptr[HEDLEY_ARRAY_PARAM(4)]) {
     return vld1_f64_x4(ptr);
   #else
     simde_float64x1_private a_[4];
-    for (size_t i = 0; i < 4; i++) {
-      a_[i].values[0] = ptr[i];
-    }
+    #if defined(SIMDE_RISCV_V_NATIVE)
+      a_[0].sv64 = __riscv_vle64_v_f64m1(ptr , 1);
+      a_[1].sv64 = __riscv_vle64_v_f64m1(ptr+1 , 1);
+      a_[2].sv64 = __riscv_vle64_v_f64m1(ptr+2 , 1);
+      a_[3].sv64 = __riscv_vle64_v_f64m1(ptr+3 , 1);
+    #else
+      for (size_t i = 0; i < 4; i++) {
+        a_[i].values[0] = ptr[i];
+      }
+    #endif
     simde_float64x1x4_t s_ = { { simde_float64x1_from_private(a_[0]),
                                  simde_float64x1_from_private(a_[1]),
                                  simde_float64x1_from_private(a_[2]),
@@ -126,9 +148,16 @@ simde_vld1_s8_x4(int8_t const ptr[HEDLEY_ARRAY_PARAM(32)]) {
     return vld1_s8_x4(ptr);
   #else
     simde_int8x8_private a_[4];
-    for (size_t i = 0; i < 32; i++) {
-      a_[i / 8].values[i % 8] = ptr[i];
-    }
+    #if defined(SIMDE_RISCV_V_NATIVE)
+      a_[0].sv64 = __riscv_vle8_v_i8m1(ptr , 8);
+      a_[1].sv64 = __riscv_vle8_v_i8m1(ptr+8 , 8);
+      a_[2].sv64 = __riscv_vle8_v_i8m1(ptr+16 , 8);
+      a_[3].sv64 = __riscv_vle8_v_i8m1(ptr+24 , 8);
+    #else
+      for (size_t i = 0; i < 32; i++) {
+        a_[i / 8].values[i % 8] = ptr[i];
+      }
+    #endif
     simde_int8x8x4_t s_ = { { simde_int8x8_from_private(a_[0]),
                               simde_int8x8_from_private(a_[1]),
                               simde_int8x8_from_private(a_[2]),
@@ -151,9 +180,16 @@ simde_vld1_s16_x4(int16_t const ptr[HEDLEY_ARRAY_PARAM(16)]) {
     return vld1_s16_x4(ptr);
   #else
     simde_int16x4_private a_[4];
-    for (size_t i = 0; i < 16; i++) {
-      a_[i / 4].values[i % 4] = ptr[i];
-    }
+    #if defined(SIMDE_RISCV_V_NATIVE)
+      a_[0].sv64 = __riscv_vle16_v_i16m1(ptr , 4);
+      a_[1].sv64 = __riscv_vle16_v_i16m1(ptr+4 , 4);
+      a_[2].sv64 = __riscv_vle16_v_i16m1(ptr+8 , 4);
+      a_[3].sv64 = __riscv_vle16_v_i16m1(ptr+12 , 4);
+    #else
+      for (size_t i = 0; i < 16; i++) {
+        a_[i / 4].values[i % 4] = ptr[i];
+      }
+    #endif
     simde_int16x4x4_t s_ = { { simde_int16x4_from_private(a_[0]),
                                simde_int16x4_from_private(a_[1]),
                                simde_int16x4_from_private(a_[2]),
@@ -176,9 +212,16 @@ simde_vld1_s32_x4(int32_t const ptr[HEDLEY_ARRAY_PARAM(8)]) {
     return vld1_s32_x4(ptr);
   #else
     simde_int32x2_private a_[4];
-    for (size_t i = 0; i < 8; i++) {
-      a_[i / 2].values[i % 2] = ptr[i];
-    }
+    #if defined(SIMDE_RISCV_V_NATIVE)
+      a_[0].sv64 = __riscv_vle32_v_i32m1(ptr , 2);
+      a_[1].sv64 = __riscv_vle32_v_i32m1(ptr+2 , 2);
+      a_[2].sv64 = __riscv_vle32_v_i32m1(ptr+4 , 2);
+      a_[3].sv64 = __riscv_vle32_v_i32m1(ptr+6 , 2);
+    #else
+      for (size_t i = 0; i < 8; i++) {
+        a_[i / 2].values[i % 2] = ptr[i];
+      }
+    #endif
     simde_int32x2x4_t s_ = { { simde_int32x2_from_private(a_[0]),
                                simde_int32x2_from_private(a_[1]),
                                simde_int32x2_from_private(a_[2]),
@@ -201,9 +244,16 @@ simde_vld1_s64_x4(int64_t const ptr[HEDLEY_ARRAY_PARAM(4)]) {
     return vld1_s64_x4(ptr);
   #else
     simde_int64x1_private a_[4];
-    for (size_t i = 0; i < 4; i++) {
-      a_[i].values[0] = ptr[i];
-    }
+    #if defined(SIMDE_RISCV_V_NATIVE)
+      a_[0].sv64 = __riscv_vle64_v_i64m1(ptr , 1);
+      a_[1].sv64 = __riscv_vle64_v_i64m1(ptr+1 , 1);
+      a_[2].sv64 = __riscv_vle64_v_i64m1(ptr+2 , 1);
+      a_[3].sv64 = __riscv_vle64_v_i64m1(ptr+3 , 1);
+    #else
+      for (size_t i = 0; i < 4; i++) {
+        a_[i].values[0] = ptr[i];
+      }
+    #endif
     simde_int64x1x4_t s_ = { { simde_int64x1_from_private(a_[0]),
                                simde_int64x1_from_private(a_[1]),
                                simde_int64x1_from_private(a_[2]),
@@ -226,9 +276,16 @@ simde_vld1_u8_x4(uint8_t const ptr[HEDLEY_ARRAY_PARAM(32)]) {
     return vld1_u8_x4(ptr);
   #else
     simde_uint8x8_private a_[4];
-    for (size_t i = 0; i < 32; i++) {
-      a_[i / 8].values[i % 8] = ptr[i];
-    }
+    #if defined(SIMDE_RISCV_V_NATIVE)
+      a_[0].sv64 = __riscv_vle8_v_u8m1(ptr , 8);
+      a_[1].sv64 = __riscv_vle8_v_u8m1(ptr+8 , 8);
+      a_[2].sv64 = __riscv_vle8_v_u8m1(ptr+16 , 8);
+      a_[3].sv64 = __riscv_vle8_v_u8m1(ptr+24 , 8);
+    #else
+      for (size_t i = 0; i < 32; i++) {
+        a_[i / 8].values[i % 8] = ptr[i];
+      }
+    #endif
     simde_uint8x8x4_t s_ = { { simde_uint8x8_from_private(a_[0]),
                                simde_uint8x8_from_private(a_[1]),
                                simde_uint8x8_from_private(a_[2]),
@@ -251,9 +308,16 @@ simde_vld1_u16_x4(uint16_t const ptr[HEDLEY_ARRAY_PARAM(16)]) {
     return vld1_u16_x4(ptr);
   #else
     simde_uint16x4_private a_[4];
-    for (size_t i = 0; i < 16; i++) {
-      a_[i / 4].values[i % 4] = ptr[i];
-    }
+    #if defined(SIMDE_RISCV_V_NATIVE)
+      a_[0].sv64 = __riscv_vle16_v_u16m1(ptr , 4);
+      a_[1].sv64 = __riscv_vle16_v_u16m1(ptr+4 , 4);
+      a_[2].sv64 = __riscv_vle16_v_u16m1(ptr+8 , 4);
+      a_[3].sv64 = __riscv_vle16_v_u16m1(ptr+12 , 4);
+    #else
+      for (size_t i = 0; i < 16; i++) {
+        a_[i / 4].values[i % 4] = ptr[i];
+      }
+    #endif
     simde_uint16x4x4_t s_ = { { simde_uint16x4_from_private(a_[0]),
                                 simde_uint16x4_from_private(a_[1]),
                                 simde_uint16x4_from_private(a_[2]),
@@ -276,9 +340,16 @@ simde_vld1_u32_x4(uint32_t const ptr[HEDLEY_ARRAY_PARAM(8)]) {
     return vld1_u32_x4(ptr);
   #else
     simde_uint32x2_private a_[4];
-    for (size_t i = 0; i < 8; i++) {
-      a_[i / 2].values[i % 2] = ptr[i];
-    }
+    #if defined(SIMDE_RISCV_V_NATIVE)
+      a_[0].sv64 = __riscv_vle32_v_u32m1(ptr , 2);
+      a_[1].sv64 = __riscv_vle32_v_u32m1(ptr+2 , 2);
+      a_[2].sv64 = __riscv_vle32_v_u32m1(ptr+4 , 2);
+      a_[3].sv64 = __riscv_vle32_v_u32m1(ptr+6 , 2);
+    #else
+      for (size_t i = 0; i < 8; i++) {
+        a_[i / 2].values[i % 2] = ptr[i];
+      }
+    #endif
     simde_uint32x2x4_t s_ = { { simde_uint32x2_from_private(a_[0]),
                                 simde_uint32x2_from_private(a_[1]),
                                 simde_uint32x2_from_private(a_[2]),
@@ -301,9 +372,16 @@ simde_vld1_u64_x4(uint64_t const ptr[HEDLEY_ARRAY_PARAM(4)]) {
     return vld1_u64_x4(ptr);
   #else
     simde_uint64x1_private a_[4];
-    for (size_t i = 0; i < 4; i++) {
-      a_[i].values[0] = ptr[i];
-    }
+    #if defined(SIMDE_RISCV_V_NATIVE)
+      a_[0].sv64 = __riscv_vle64_v_u64m1(ptr , 1);
+      a_[1].sv64 = __riscv_vle64_v_u64m1(ptr+1 , 1);
+      a_[2].sv64 = __riscv_vle64_v_u64m1(ptr+2 , 1);
+      a_[3].sv64 = __riscv_vle64_v_u64m1(ptr+3 , 1);
+    #else
+      for (size_t i = 0; i < 4; i++) {
+        a_[i].values[0] = ptr[i];
+      }
+    #endif
     simde_uint64x1x4_t s_ = { { simde_uint64x1_from_private(a_[0]),
                                 simde_uint64x1_from_private(a_[1]),
                                 simde_uint64x1_from_private(a_[2]),

--- a/simde/arm/neon/ld1q_x2.h
+++ b/simde/arm/neon/ld1q_x2.h
@@ -25,6 +25,7 @@
  *   2021      Zhi An Ng <zhin@google.com> (Copyright owned by Google, LLC)
  *   2021      Décio Luiz Gazzoni Filho <decio@decpp.net>
  *   2023      Yi-Yen Chung <eric681@andestech.com> (Copyright owned by Andes Technology)
+ *   2023      Chi-Wei Chu <wewe5215@gapp.nthu.edu.tw>
  */
 
 #if !defined(SIMDE_ARM_NEON_LD1Q_X2_H)
@@ -52,9 +53,14 @@ simde_vld1q_f16_x2(simde_float16 const ptr[HEDLEY_ARRAY_PARAM(16)]) {
     return vld1q_f16_x2(ptr);
   #else
     simde_float16x8_private a_[2];
-    for (size_t i = 0; i < 16; i++) {
-      a_[i / 8].values[i % 8] = ptr[i];
-    }
+    #if defined(SIMDE_RISCV_V_NATIVE) && SIMDE_ARCH_RISCV_ZVFH
+      a_[0].sv128 = __riscv_vle16_v_f16m1((_Float16 *)ptr , 8);
+      a_[1].sv128 = __riscv_vle16_v_f16m1((_Float16 *)(ptr+8) , 8);
+    #else
+      for (size_t i = 0; i < 16; i++) {
+        a_[i / 8].values[i % 8] = ptr[i];
+      }
+    #endif
     simde_float16x8x2_t s_ = { { simde_float16x8_from_private(a_[0]),
                                  simde_float16x8_from_private(a_[1]) } };
     return s_;
@@ -75,9 +81,14 @@ simde_vld1q_f32_x2(simde_float32 const ptr[HEDLEY_ARRAY_PARAM(8)]) {
     return vld1q_f32_x2(ptr);
   #else
     simde_float32x4_private a_[2];
-    for (size_t i = 0; i < 8; i++) {
-      a_[i / 4].values[i % 4] = ptr[i];
-    }
+    #if defined(SIMDE_RISCV_V_NATIVE)
+      a_[0].sv128 = __riscv_vle32_v_f32m1(ptr , 4);
+      a_[1].sv128 = __riscv_vle32_v_f32m1(ptr+4 , 4);
+    #else
+      for (size_t i = 0; i < 8; i++) {
+        a_[i / 4].values[i % 4] = ptr[i];
+      }
+    #endif
     simde_float32x4x2_t s_ = { { simde_float32x4_from_private(a_[0]),
                                  simde_float32x4_from_private(a_[1]) } };
     return s_;
@@ -98,9 +109,14 @@ simde_vld1q_f64_x2(simde_float64 const ptr[HEDLEY_ARRAY_PARAM(4)]) {
     return vld1q_f64_x2(ptr);
   #else
     simde_float64x2_private a_[2];
-    for (size_t i = 0; i < 4; i++) {
-      a_[i / 2].values[i % 2] = ptr[i];
-    }
+    #if defined(SIMDE_RISCV_V_NATIVE)
+      a_[0].sv128 = __riscv_vle64_v_f64m1(ptr , 2);
+      a_[1].sv128 = __riscv_vle64_v_f64m1(ptr+2 , 2);
+    #else
+      for (size_t i = 0; i < 4; i++) {
+        a_[i / 2].values[i % 2] = ptr[i];
+      }
+    #endif
     simde_float64x2x2_t s_ = { { simde_float64x2_from_private(a_[0]),
                                  simde_float64x2_from_private(a_[1]) } };
     return s_;
@@ -121,9 +137,14 @@ simde_vld1q_s8_x2(int8_t const ptr[HEDLEY_ARRAY_PARAM(32)]) {
     return vld1q_s8_x2(ptr);
   #else
     simde_int8x16_private a_[2];
-    for (size_t i = 0; i < 32; i++) {
-      a_[i / 16].values[i % 16] = ptr[i];
-    }
+    #if defined(SIMDE_RISCV_V_NATIVE)
+      a_[0].sv128 = __riscv_vle8_v_i8m1(ptr , 16);
+      a_[1].sv128 = __riscv_vle8_v_i8m1(ptr+16 , 16);
+    #else
+      for (size_t i = 0; i < 32; i++) {
+        a_[i / 16].values[i % 16] = ptr[i];
+      }
+    #endif
     simde_int8x16x2_t s_ = { { simde_int8x16_from_private(a_[0]),
                                simde_int8x16_from_private(a_[1]) } };
     return s_;
@@ -144,9 +165,14 @@ simde_vld1q_s16_x2(int16_t const ptr[HEDLEY_ARRAY_PARAM(16)]) {
     return vld1q_s16_x2(ptr);
   #else
     simde_int16x8_private a_[2];
-    for (size_t i = 0; i < 16; i++) {
-      a_[i / 8].values[i % 8] = ptr[i];
-    }
+    #if defined(SIMDE_RISCV_V_NATIVE)
+      a_[0].sv128 = __riscv_vle16_v_i16m1(ptr , 8);
+      a_[1].sv128 = __riscv_vle16_v_i16m1(ptr+8 , 8);
+    #else
+      for (size_t i = 0; i < 16; i++) {
+        a_[i / 8].values[i % 8] = ptr[i];
+      }
+    #endif
     simde_int16x8x2_t s_ = { { simde_int16x8_from_private(a_[0]),
                                simde_int16x8_from_private(a_[1]) } };
     return s_;
@@ -167,9 +193,14 @@ simde_vld1q_s32_x2(int32_t const ptr[HEDLEY_ARRAY_PARAM(8)]) {
     return vld1q_s32_x2(ptr);
   #else
     simde_int32x4_private a_[2];
-    for (size_t i = 0; i < 8; i++) {
-      a_[i / 4].values[i % 4] = ptr[i];
-    }
+    #if defined(SIMDE_RISCV_V_NATIVE)
+      a_[0].sv128 = __riscv_vle32_v_i32m1(ptr , 4);
+      a_[1].sv128 = __riscv_vle32_v_i32m1(ptr+4 , 4);
+    #else
+      for (size_t i = 0; i < 8; i++) {
+        a_[i / 4].values[i % 4] = ptr[i];
+      }
+    #endif
     simde_int32x4x2_t s_ = { { simde_int32x4_from_private(a_[0]),
                                simde_int32x4_from_private(a_[1]) } };
     return s_;
@@ -190,9 +221,14 @@ simde_vld1q_s64_x2(int64_t const ptr[HEDLEY_ARRAY_PARAM(4)]) {
     return vld1q_s64_x2(ptr);
   #else
     simde_int64x2_private a_[2];
-    for (size_t i = 0; i < 4; i++) {
-      a_[i / 2].values[i % 2] = ptr[i];
-    }
+    #if defined(SIMDE_RISCV_V_NATIVE)
+      a_[0].sv128 = __riscv_vle64_v_i64m1(ptr , 2);
+      a_[1].sv128 = __riscv_vle64_v_i64m1(ptr+2 , 2);
+    #else
+      for (size_t i = 0; i < 4; i++) {
+        a_[i / 2].values[i % 2] = ptr[i];
+      }
+    #endif
     simde_int64x2x2_t s_ = { { simde_int64x2_from_private(a_[0]),
                                simde_int64x2_from_private(a_[1]) } };
     return s_;
@@ -213,9 +249,14 @@ simde_vld1q_u8_x2(uint8_t const ptr[HEDLEY_ARRAY_PARAM(32)]) {
     return vld1q_u8_x2(ptr);
   #else
     simde_uint8x16_private a_[2];
-    for (size_t i = 0; i < 32; i++) {
-      a_[i / 16].values[i % 16] = ptr[i];
-    }
+    #if defined(SIMDE_RISCV_V_NATIVE)
+      a_[0].sv128 = __riscv_vle8_v_u8m1(ptr , 16);
+      a_[1].sv128 = __riscv_vle8_v_u8m1(ptr+16 , 16);
+    #else
+      for (size_t i = 0; i < 32; i++) {
+        a_[i / 16].values[i % 16] = ptr[i];
+      }
+    #endif
     simde_uint8x16x2_t s_ = { { simde_uint8x16_from_private(a_[0]),
                                 simde_uint8x16_from_private(a_[1]) } };
     return s_;
@@ -236,9 +277,14 @@ simde_vld1q_u16_x2(uint16_t const ptr[HEDLEY_ARRAY_PARAM(16)]) {
     return vld1q_u16_x2(ptr);
   #else
     simde_uint16x8_private a_[2];
-    for (size_t i = 0; i < 16; i++) {
-      a_[i / 8].values[i % 8] = ptr[i];
-    }
+    #if defined(SIMDE_RISCV_V_NATIVE)
+      a_[0].sv128 = __riscv_vle16_v_u16m1(ptr , 8);
+      a_[1].sv128 = __riscv_vle16_v_u16m1(ptr+8 , 8);
+    #else
+      for (size_t i = 0; i < 16; i++) {
+        a_[i / 8].values[i % 8] = ptr[i];
+      }
+    #endif
     simde_uint16x8x2_t s_ = { { simde_uint16x8_from_private(a_[0]),
                                 simde_uint16x8_from_private(a_[1]) } };
     return s_;
@@ -259,9 +305,14 @@ simde_vld1q_u32_x2(uint32_t const ptr[HEDLEY_ARRAY_PARAM(8)]) {
     return vld1q_u32_x2(ptr);
   #else
     simde_uint32x4_private a_[2];
-    for (size_t i = 0; i < 8; i++) {
-      a_[i / 4].values[i % 4] = ptr[i];
-    }
+    #if defined(SIMDE_RISCV_V_NATIVE)
+      a_[0].sv128 = __riscv_vle32_v_u32m1(ptr , 4);
+      a_[1].sv128 = __riscv_vle32_v_u32m1(ptr+4 , 4);
+    #else
+      for (size_t i = 0; i < 8; i++) {
+        a_[i / 4].values[i % 4] = ptr[i];
+      }
+    #endif
     simde_uint32x4x2_t s_ = { { simde_uint32x4_from_private(a_[0]),
                                 simde_uint32x4_from_private(a_[1]) } };
     return s_;
@@ -282,9 +333,14 @@ simde_vld1q_u64_x2(uint64_t const ptr[HEDLEY_ARRAY_PARAM(4)]) {
     return vld1q_u64_x2(ptr);
   #else
     simde_uint64x2_private a_[2];
-    for (size_t i = 0; i < 4; i++) {
-      a_[i / 2].values[i % 2] = ptr[i];
-    }
+    #if defined(SIMDE_RISCV_V_NATIVE)
+      a_[0].sv128 = __riscv_vle64_v_u64m1(ptr , 2);
+      a_[1].sv128 = __riscv_vle64_v_u64m1(ptr+2 , 2);
+    #else
+      for (size_t i = 0; i < 4; i++) {
+        a_[i / 2].values[i % 2] = ptr[i];
+      }
+    #endif
     simde_uint64x2x2_t s_ = { { simde_uint64x2_from_private(a_[0]),
                                 simde_uint64x2_from_private(a_[1]) } };
     return s_;

--- a/simde/arm/neon/ld1q_x3.h
+++ b/simde/arm/neon/ld1q_x3.h
@@ -24,6 +24,7 @@
  *   2020      Evan Nemerson <evan@nemerson.com>
  *   2021      Zhi An Ng <zhin@google.com> (Copyright owned by Google, LLC)
  *   2023      Yi-Yen Chung <eric681@andestech.com> (Copyright owned by Andes Technology)
+ *   2023      Chi-Wei Chu <wewe5215@gapp.nthu.edu.tw>
  */
 
 #if !defined(SIMDE_ARM_NEON_LD1Q_X3_H)
@@ -50,9 +51,15 @@ simde_vld1q_f16_x3(simde_float16 const ptr[HEDLEY_ARRAY_PARAM(24)]) {
     return vld1q_f16_x3(ptr);
   #else
     simde_float16x8_private a_[3];
-    for (size_t i = 0; i < 24; i++) {
-      a_[i / 8].values[i % 8] = ptr[i];
-    }
+    #if defined(SIMDE_RISCV_V_NATIVE) && SIMDE_ARCH_RISCV_ZVFH
+      a_[0].sv128 = __riscv_vle16_v_f16m1((_Float16 *)ptr , 8);
+      a_[1].sv128 = __riscv_vle16_v_f16m1((_Float16 *)(ptr+8) , 8);
+      a_[2].sv128 = __riscv_vle16_v_f16m1((_Float16 *)(ptr+16) , 8);
+    #else
+      for (size_t i = 0; i < 24; i++) {
+        a_[i / 8].values[i % 8] = ptr[i];
+      }
+    #endif
     simde_float16x8x3_t s_ = { { simde_float16x8_from_private(a_[0]),
                                  simde_float16x8_from_private(a_[1]),
                                  simde_float16x8_from_private(a_[2]) } };
@@ -74,9 +81,15 @@ simde_vld1q_f32_x3(simde_float32 const ptr[HEDLEY_ARRAY_PARAM(12)]) {
     return vld1q_f32_x3(ptr);
   #else
     simde_float32x4_private a_[3];
-    for (size_t i = 0; i < 12; i++) {
-      a_[i / 4].values[i % 4] = ptr[i];
-    }
+    #if defined(SIMDE_RISCV_V_NATIVE)
+      a_[0].sv128 = __riscv_vle32_v_f32m1(ptr , 4);
+      a_[1].sv128 = __riscv_vle32_v_f32m1(ptr+4 , 4);
+      a_[2].sv128 = __riscv_vle32_v_f32m1(ptr+8 , 4);
+    #else
+      for (size_t i = 0; i < 12; i++) {
+        a_[i / 4].values[i % 4] = ptr[i];
+      }
+    #endif
     simde_float32x4x3_t s_ = { { simde_float32x4_from_private(a_[0]),
                                  simde_float32x4_from_private(a_[1]),
                                  simde_float32x4_from_private(a_[2]) } };
@@ -98,9 +111,15 @@ simde_vld1q_f64_x3(simde_float64 const ptr[HEDLEY_ARRAY_PARAM(6)]) {
     return vld1q_f64_x3(ptr);
   #else
     simde_float64x2_private a_[3];
-    for (size_t i = 0; i < 6; i++) {
-      a_[i / 2].values[i % 2] = ptr[i];
-    }
+    #if defined(SIMDE_RISCV_V_NATIVE)
+      a_[0].sv128 = __riscv_vle64_v_f64m1(ptr , 2);
+      a_[1].sv128 = __riscv_vle64_v_f64m1(ptr+2 , 2);
+      a_[2].sv128 = __riscv_vle64_v_f64m1(ptr+4 , 2);
+    #else
+      for (size_t i = 0; i < 6; i++) {
+        a_[i / 2].values[i % 2] = ptr[i];
+      }
+    #endif
     simde_float64x2x3_t s_ = { { simde_float64x2_from_private(a_[0]),
                                  simde_float64x2_from_private(a_[1]),
                                  simde_float64x2_from_private(a_[2]) } };
@@ -122,9 +141,15 @@ simde_vld1q_s8_x3(int8_t const ptr[HEDLEY_ARRAY_PARAM(48)]) {
     return vld1q_s8_x3(ptr);
   #else
     simde_int8x16_private a_[3];
-    for (size_t i = 0; i < 48; i++) {
-      a_[i / 16].values[i % 16] = ptr[i];
-    }
+    #if defined(SIMDE_RISCV_V_NATIVE)
+      a_[0].sv128 = __riscv_vle8_v_i8m1(ptr , 16);
+      a_[1].sv128 = __riscv_vle8_v_i8m1(ptr+16 , 16);
+      a_[2].sv128 = __riscv_vle8_v_i8m1(ptr+32 , 16);
+    #else
+      for (size_t i = 0; i < 48; i++) {
+        a_[i / 16].values[i % 16] = ptr[i];
+      }
+    #endif
     simde_int8x16x3_t s_ = { { simde_int8x16_from_private(a_[0]),
                                simde_int8x16_from_private(a_[1]),
                                simde_int8x16_from_private(a_[2]) } };
@@ -146,9 +171,15 @@ simde_vld1q_s16_x3(int16_t const ptr[HEDLEY_ARRAY_PARAM(12)]) {
     return vld1q_s16_x3(ptr);
   #else
     simde_int16x8_private a_[3];
-    for (size_t i = 0; i < 24; i++) {
-      a_[i / 8].values[i % 8] = ptr[i];
-    }
+    #if defined(SIMDE_RISCV_V_NATIVE)
+      a_[0].sv128 = __riscv_vle16_v_i16m1(ptr , 8);
+      a_[1].sv128 = __riscv_vle16_v_i16m1(ptr+8 , 8);
+      a_[2].sv128 = __riscv_vle16_v_i16m1(ptr+16 , 8);
+    #else
+      for (size_t i = 0; i < 24; i++) {
+        a_[i / 8].values[i % 8] = ptr[i];
+      }
+    #endif
     simde_int16x8x3_t s_ = { { simde_int16x8_from_private(a_[0]),
                                simde_int16x8_from_private(a_[1]),
                                simde_int16x8_from_private(a_[2]) } };
@@ -170,9 +201,15 @@ simde_vld1q_s32_x3(int32_t const ptr[HEDLEY_ARRAY_PARAM(6)]) {
     return vld1q_s32_x3(ptr);
   #else
     simde_int32x4_private a_[3];
-    for (size_t i = 0; i < 12; i++) {
-      a_[i / 4].values[i % 4] = ptr[i];
-    }
+    #if defined(SIMDE_RISCV_V_NATIVE)
+      a_[0].sv128 = __riscv_vle32_v_i32m1(ptr , 4);
+      a_[1].sv128 = __riscv_vle32_v_i32m1(ptr+4 , 4);
+      a_[2].sv128 = __riscv_vle32_v_i32m1(ptr+8 , 4);
+    #else
+      for (size_t i = 0; i < 12; i++) {
+        a_[i / 4].values[i % 4] = ptr[i];
+      }
+    #endif
     simde_int32x4x3_t s_ = { { simde_int32x4_from_private(a_[0]),
                                simde_int32x4_from_private(a_[1]),
                                simde_int32x4_from_private(a_[2]) } };
@@ -194,9 +231,15 @@ simde_vld1q_s64_x3(int64_t const ptr[HEDLEY_ARRAY_PARAM(3)]) {
     return vld1q_s64_x3(ptr);
   #else
     simde_int64x2_private a_[3];
-    for (size_t i = 0; i < 6; i++) {
-      a_[i / 2].values[i % 2] = ptr[i];
-    }
+    #if defined(SIMDE_RISCV_V_NATIVE)
+      a_[0].sv128 = __riscv_vle64_v_i64m1(ptr , 2);
+      a_[1].sv128 = __riscv_vle64_v_i64m1(ptr+2 , 2);
+      a_[2].sv128 = __riscv_vle64_v_i64m1(ptr+4 , 2);
+    #else
+      for (size_t i = 0; i < 6; i++) {
+        a_[i / 2].values[i % 2] = ptr[i];
+      }
+    #endif
     simde_int64x2x3_t s_ = { { simde_int64x2_from_private(a_[0]),
                                simde_int64x2_from_private(a_[1]),
                                simde_int64x2_from_private(a_[2]) } };
@@ -218,9 +261,15 @@ simde_vld1q_u8_x3(uint8_t const ptr[HEDLEY_ARRAY_PARAM(48)]) {
     return vld1q_u8_x3(ptr);
   #else
     simde_uint8x16_private a_[3];
-    for (size_t i = 0; i < 48; i++) {
-      a_[i / 16].values[i % 16] = ptr[i];
-    }
+    #if defined(SIMDE_RISCV_V_NATIVE)
+      a_[0].sv128 = __riscv_vle8_v_u8m1(ptr , 16);
+      a_[1].sv128 = __riscv_vle8_v_u8m1(ptr+16 , 16);
+      a_[2].sv128 = __riscv_vle8_v_u8m1(ptr+32 , 16);
+    #else
+      for (size_t i = 0; i < 48; i++) {
+        a_[i / 16].values[i % 16] = ptr[i];
+      }
+    #endif
     simde_uint8x16x3_t s_ = { { simde_uint8x16_from_private(a_[0]),
                                 simde_uint8x16_from_private(a_[1]),
                                 simde_uint8x16_from_private(a_[2]) } };
@@ -242,9 +291,15 @@ simde_vld1q_u16_x3(uint16_t const ptr[HEDLEY_ARRAY_PARAM(24)]) {
     return vld1q_u16_x3(ptr);
   #else
     simde_uint16x8_private a_[3];
-    for (size_t i = 0; i < 24; i++) {
-      a_[i / 8].values[i % 8] = ptr[i];
-    }
+    #if defined(SIMDE_RISCV_V_NATIVE)
+      a_[0].sv128 = __riscv_vle16_v_u16m1(ptr , 8);
+      a_[1].sv128 = __riscv_vle16_v_u16m1(ptr+8 , 8);
+      a_[2].sv128 = __riscv_vle16_v_u16m1(ptr+16 , 8);
+    #else
+      for (size_t i = 0; i < 24; i++) {
+        a_[i / 8].values[i % 8] = ptr[i];
+      }
+    #endif
     simde_uint16x8x3_t s_ = { { simde_uint16x8_from_private(a_[0]),
                                 simde_uint16x8_from_private(a_[1]),
                                 simde_uint16x8_from_private(a_[2]) } };
@@ -266,9 +321,15 @@ simde_vld1q_u32_x3(uint32_t const ptr[HEDLEY_ARRAY_PARAM(6)]) {
     return vld1q_u32_x3(ptr);
   #else
     simde_uint32x4_private a_[3];
-    for (size_t i = 0; i < 12; i++) {
-      a_[i / 4].values[i % 4] = ptr[i];
-    }
+    #if defined(SIMDE_RISCV_V_NATIVE)
+      a_[0].sv128 = __riscv_vle32_v_u32m1(ptr , 4);
+      a_[1].sv128 = __riscv_vle32_v_u32m1(ptr+4 , 4);
+      a_[2].sv128 = __riscv_vle32_v_u32m1(ptr+8 , 4);
+    #else
+      for (size_t i = 0; i < 12; i++) {
+        a_[i / 4].values[i % 4] = ptr[i];
+      }
+    #endif
     simde_uint32x4x3_t s_ = { { simde_uint32x4_from_private(a_[0]),
                                 simde_uint32x4_from_private(a_[1]),
                                 simde_uint32x4_from_private(a_[2]) } };
@@ -290,9 +351,15 @@ simde_vld1q_u64_x3(uint64_t const ptr[HEDLEY_ARRAY_PARAM(3)]) {
     return vld1q_u64_x3(ptr);
   #else
     simde_uint64x2_private a_[3];
-    for (size_t i = 0; i < 6; i++) {
-      a_[i / 2].values[i % 2] = ptr[i];
-    }
+    #if defined(SIMDE_RISCV_V_NATIVE)
+      a_[0].sv128 = __riscv_vle64_v_u64m1(ptr , 2);
+      a_[1].sv128 = __riscv_vle64_v_u64m1(ptr+2 , 2);
+      a_[2].sv128 = __riscv_vle64_v_u64m1(ptr+4 , 2);
+    #else
+      for (size_t i = 0; i < 6; i++) {
+        a_[i / 2].values[i % 2] = ptr[i];
+      }
+    #endif
     simde_uint64x2x3_t s_ = { { simde_uint64x2_from_private(a_[0]),
                                 simde_uint64x2_from_private(a_[1]),
                                 simde_uint64x2_from_private(a_[2]) } };

--- a/simde/arm/neon/ld1q_x4.h
+++ b/simde/arm/neon/ld1q_x4.h
@@ -25,6 +25,7 @@
  *   2021      Zhi An Ng <zhin@google.com> (Copyright owned by Google, LLC)
  *   2021      Décio Luiz Gazzoni Filho <decio@decpp.net>
  *   2023      Yi-Yen Chung <eric681@andestech.com> (Copyright owned by Andes Technology)
+ *   2023      Chi-Wei Chu <wewe5215@gapp.nthu.edu.tw>
  */
 
 #if !defined(SIMDE_ARM_NEON_LD1Q_X4_H)
@@ -51,9 +52,16 @@ simde_vld1q_f16_x4(simde_float16 const ptr[HEDLEY_ARRAY_PARAM(32)]) {
     return vld1q_f16_x4(ptr);
   #else
     simde_float16x8_private a_[4];
-    for (size_t i = 0; i < 32; i++) {
-      a_[i / 8].values[i % 8] = ptr[i];
-    }
+    #if defined(SIMDE_RISCV_V_NATIVE) && SIMDE_ARCH_RISCV_ZVFH
+      a_[0].sv128 = __riscv_vle16_v_f16m1((_Float16 *)ptr , 8);
+      a_[1].sv128 = __riscv_vle16_v_f16m1((_Float16 *)(ptr+8) , 8);
+      a_[2].sv128 = __riscv_vle16_v_f16m1((_Float16 *)(ptr+16) , 8);
+      a_[3].sv128 = __riscv_vle16_v_f16m1((_Float16 *)(ptr+24) , 8);
+    #else
+      for (size_t i = 0; i < 32; i++) {
+        a_[i / 8].values[i % 8] = ptr[i];
+      }
+    #endif
     simde_float16x8x4_t s_ = { { simde_float16x8_from_private(a_[0]),
                                  simde_float16x8_from_private(a_[1]),
                                  simde_float16x8_from_private(a_[2]),
@@ -76,9 +84,16 @@ simde_vld1q_f32_x4(simde_float32 const ptr[HEDLEY_ARRAY_PARAM(16)]) {
     return vld1q_f32_x4(ptr);
   #else
     simde_float32x4_private a_[4];
-    for (size_t i = 0; i < 16; i++) {
-      a_[i / 4].values[i % 4] = ptr[i];
-    }
+    #if defined(SIMDE_RISCV_V_NATIVE)
+      a_[0].sv128 = __riscv_vle32_v_f32m1(ptr , 4);
+      a_[1].sv128 = __riscv_vle32_v_f32m1(ptr+4 , 4);
+      a_[2].sv128 = __riscv_vle32_v_f32m1(ptr+8 , 4);
+      a_[3].sv128 = __riscv_vle32_v_f32m1(ptr+12 , 4);
+    #else
+      for (size_t i = 0; i < 16; i++) {
+        a_[i / 4].values[i % 4] = ptr[i];
+      }
+    #endif
     simde_float32x4x4_t s_ = { { simde_float32x4_from_private(a_[0]),
                                  simde_float32x4_from_private(a_[1]),
                                  simde_float32x4_from_private(a_[2]),
@@ -101,9 +116,16 @@ simde_vld1q_f64_x4(simde_float64 const ptr[HEDLEY_ARRAY_PARAM(8)]) {
     return vld1q_f64_x4(ptr);
   #else
     simde_float64x2_private a_[4];
-    for (size_t i = 0; i < 8; i++) {
-      a_[i / 2].values[i % 2] = ptr[i];
-    }
+    #if defined(SIMDE_RISCV_V_NATIVE)
+      a_[0].sv128 = __riscv_vle64_v_f64m1(ptr , 2);
+      a_[1].sv128 = __riscv_vle64_v_f64m1(ptr+2 , 2);
+      a_[2].sv128 = __riscv_vle64_v_f64m1(ptr+4 , 2);
+      a_[3].sv128 = __riscv_vle64_v_f64m1(ptr+6 , 2);
+    #else
+      for (size_t i = 0; i < 8; i++) {
+        a_[i / 2].values[i % 2] = ptr[i];
+      }
+    #endif
     simde_float64x2x4_t s_ = { { simde_float64x2_from_private(a_[0]),
                                  simde_float64x2_from_private(a_[1]),
                                  simde_float64x2_from_private(a_[2]),
@@ -126,9 +148,16 @@ simde_vld1q_s8_x4(int8_t const ptr[HEDLEY_ARRAY_PARAM(64)]) {
     return vld1q_s8_x4(ptr);
   #else
     simde_int8x16_private a_[4];
-    for (size_t i = 0; i < 64; i++) {
-      a_[i / 16].values[i % 16] = ptr[i];
-    }
+    #if defined(SIMDE_RISCV_V_NATIVE)
+      a_[0].sv128 = __riscv_vle8_v_i8m1(ptr , 16);
+      a_[1].sv128 = __riscv_vle8_v_i8m1(ptr+16 , 16);
+      a_[2].sv128 = __riscv_vle8_v_i8m1(ptr+32 , 16);
+      a_[3].sv128 = __riscv_vle8_v_i8m1(ptr+48 , 16);
+    #else
+      for (size_t i = 0; i < 64; i++) {
+        a_[i / 16].values[i % 16] = ptr[i];
+      }
+    #endif
     simde_int8x16x4_t s_ = { { simde_int8x16_from_private(a_[0]),
                                simde_int8x16_from_private(a_[1]),
                                simde_int8x16_from_private(a_[2]),
@@ -151,9 +180,16 @@ simde_vld1q_s16_x4(int16_t const ptr[HEDLEY_ARRAY_PARAM(32)]) {
     return vld1q_s16_x4(ptr);
   #else
     simde_int16x8_private a_[4];
-    for (size_t i = 0; i < 32; i++) {
-      a_[i / 8].values[i % 8] = ptr[i];
-    }
+    #if defined(SIMDE_RISCV_V_NATIVE)
+      a_[0].sv128 = __riscv_vle16_v_i16m1(ptr , 8);
+      a_[1].sv128 = __riscv_vle16_v_i16m1(ptr+8 , 8);
+      a_[2].sv128 = __riscv_vle16_v_i16m1(ptr+16 , 8);
+      a_[3].sv128 = __riscv_vle16_v_i16m1(ptr+24 , 8);
+    #else
+      for (size_t i = 0; i < 32; i++) {
+        a_[i / 8].values[i % 8] = ptr[i];
+      }
+    #endif
     simde_int16x8x4_t s_ = { { simde_int16x8_from_private(a_[0]),
                                simde_int16x8_from_private(a_[1]),
                                simde_int16x8_from_private(a_[2]),
@@ -176,9 +212,16 @@ simde_vld1q_s32_x4(int32_t const ptr[HEDLEY_ARRAY_PARAM(16)]) {
     return vld1q_s32_x4(ptr);
   #else
     simde_int32x4_private a_[4];
-    for (size_t i = 0; i < 16; i++) {
-      a_[i / 4].values[i % 4] = ptr[i];
-    }
+    #if defined(SIMDE_RISCV_V_NATIVE)
+      a_[0].sv128 = __riscv_vle32_v_i32m1(ptr , 4);
+      a_[1].sv128 = __riscv_vle32_v_i32m1(ptr+4 , 4);
+      a_[2].sv128 = __riscv_vle32_v_i32m1(ptr+8 , 4);
+      a_[3].sv128 = __riscv_vle32_v_i32m1(ptr+12 , 4);
+    #else
+      for (size_t i = 0; i < 16; i++) {
+        a_[i / 4].values[i % 4] = ptr[i];
+      }
+    #endif
     simde_int32x4x4_t s_ = { { simde_int32x4_from_private(a_[0]),
                                simde_int32x4_from_private(a_[1]),
                                simde_int32x4_from_private(a_[2]),
@@ -201,9 +244,16 @@ simde_vld1q_s64_x4(int64_t const ptr[HEDLEY_ARRAY_PARAM(8)]) {
     return vld1q_s64_x4(ptr);
   #else
     simde_int64x2_private a_[4];
-    for (size_t i = 0; i < 8; i++) {
-      a_[i / 2].values[i % 2] = ptr[i];
-    }
+    #if defined(SIMDE_RISCV_V_NATIVE)
+      a_[0].sv128 = __riscv_vle64_v_i64m1(ptr , 2);
+      a_[1].sv128 = __riscv_vle64_v_i64m1(ptr+2 , 2);
+      a_[2].sv128 = __riscv_vle64_v_i64m1(ptr+4 , 2);
+      a_[3].sv128 = __riscv_vle64_v_i64m1(ptr+6 , 2);
+    #else
+      for (size_t i = 0; i < 8; i++) {
+        a_[i / 2].values[i % 2] = ptr[i];
+      }
+    #endif
     simde_int64x2x4_t s_ = { { simde_int64x2_from_private(a_[0]),
                                simde_int64x2_from_private(a_[1]),
                                simde_int64x2_from_private(a_[1]),
@@ -226,9 +276,16 @@ simde_vld1q_u8_x4(uint8_t const ptr[HEDLEY_ARRAY_PARAM(64)]) {
     return vld1q_u8_x4(ptr);
   #else
     simde_uint8x16_private a_[4];
-    for (size_t i = 0; i < 64; i++) {
-      a_[i / 16].values[i % 16] = ptr[i];
-    }
+    #if defined(SIMDE_RISCV_V_NATIVE)
+      a_[0].sv128 = __riscv_vle8_v_u8m1(ptr , 16);
+      a_[1].sv128 = __riscv_vle8_v_u8m1(ptr+16 , 16);
+      a_[2].sv128 = __riscv_vle8_v_u8m1(ptr+32 , 16);
+      a_[3].sv128 = __riscv_vle8_v_u8m1(ptr+48 , 16);
+    #else
+      for (size_t i = 0; i < 64; i++) {
+        a_[i / 16].values[i % 16] = ptr[i];
+      }
+    #endif
     simde_uint8x16x4_t s_ = { { simde_uint8x16_from_private(a_[0]),
                                 simde_uint8x16_from_private(a_[1]),
                                 simde_uint8x16_from_private(a_[2]),
@@ -251,9 +308,16 @@ simde_vld1q_u16_x4(uint16_t const ptr[HEDLEY_ARRAY_PARAM(32)]) {
     return vld1q_u16_x4(ptr);
   #else
     simde_uint16x8_private a_[4];
-    for (size_t i = 0; i < 32; i++) {
-      a_[i / 8].values[i % 8] = ptr[i];
-    }
+    #if defined(SIMDE_RISCV_V_NATIVE)
+      a_[0].sv128 = __riscv_vle16_v_u16m1(ptr , 8);
+      a_[1].sv128 = __riscv_vle16_v_u16m1(ptr+8 , 8);
+      a_[2].sv128 = __riscv_vle16_v_u16m1(ptr+16 , 8);
+      a_[3].sv128 = __riscv_vle16_v_u16m1(ptr+24 , 8);
+    #else
+      for (size_t i = 0; i < 32; i++) {
+        a_[i / 8].values[i % 8] = ptr[i];
+      }
+    #endif
     simde_uint16x8x4_t s_ = { { simde_uint16x8_from_private(a_[0]),
                                 simde_uint16x8_from_private(a_[1]),
                                 simde_uint16x8_from_private(a_[2]),
@@ -276,9 +340,16 @@ simde_vld1q_u32_x4(uint32_t const ptr[HEDLEY_ARRAY_PARAM(16)]) {
     return vld1q_u32_x4(ptr);
   #else
     simde_uint32x4_private a_[4];
-    for (size_t i = 0; i < 16; i++) {
-      a_[i / 4].values[i % 4] = ptr[i];
-    }
+    #if defined(SIMDE_RISCV_V_NATIVE)
+      a_[0].sv128 = __riscv_vle32_v_u32m1(ptr , 4);
+      a_[1].sv128 = __riscv_vle32_v_u32m1(ptr+4 , 4);
+      a_[2].sv128 = __riscv_vle32_v_u32m1(ptr+8 , 4);
+      a_[3].sv128 = __riscv_vle32_v_u32m1(ptr+12 , 4);
+    #else
+      for (size_t i = 0; i < 16; i++) {
+        a_[i / 4].values[i % 4] = ptr[i];
+      }
+    #endif
     simde_uint32x4x4_t s_ = { { simde_uint32x4_from_private(a_[0]),
                                 simde_uint32x4_from_private(a_[1]),
                                 simde_uint32x4_from_private(a_[2]),
@@ -301,9 +372,16 @@ simde_vld1q_u64_x4(uint64_t const ptr[HEDLEY_ARRAY_PARAM(8)]) {
     return vld1q_u64_x4(ptr);
   #else
     simde_uint64x2_private a_[4];
-    for (size_t i = 0; i < 8; i++) {
-      a_[i / 2].values[i % 2] = ptr[i];
-    }
+    #if defined(SIMDE_RISCV_V_NATIVE)
+      a_[0].sv128 = __riscv_vle64_v_u64m1(ptr , 2);
+      a_[1].sv128 = __riscv_vle64_v_u64m1(ptr+2 , 2);
+      a_[2].sv128 = __riscv_vle64_v_u64m1(ptr+4 , 2);
+      a_[3].sv128 = __riscv_vle64_v_u64m1(ptr+6 , 2);
+    #else
+      for (size_t i = 0; i < 8; i++) {
+        a_[i / 2].values[i % 2] = ptr[i];
+      }
+    #endif
     simde_uint64x2x4_t s_ = { { simde_uint64x2_from_private(a_[0]),
                                 simde_uint64x2_from_private(a_[1]),
                                 simde_uint64x2_from_private(a_[2]),

--- a/simde/arm/neon/ld2.h
+++ b/simde/arm/neon/ld2.h
@@ -23,6 +23,7 @@
  * Copyright:
  *   2021      Zhi An Ng <zhin@google.com> (Copyright owned by Google, LLC)
  *   2023      Yi-Yen Chung <eric681@andestech.com> (Copyright owned by Andes Technology)
+ *   2023      Chi-Wei Chu <wewe5215@gapp.nthu.edu.tw>
  */
 /* FIXME :  The vector lengths of RVV and Neon may differ, so copying sizeof(union) of bytes
             from one memory location to another may pollute memory.
@@ -60,6 +61,16 @@ simde_vld2_s8(int8_t const ptr[HEDLEY_ARRAY_PARAM(16)]) {
       simde_vget_high_s8(q)
     };
     return u;
+  // #elif defined(SIMDE_RISCV_V_NATIVE) && (SIMDE_NATURAL_VECTOR_SIZE >= 128)
+  //   simde_int8x8_private a_[2];
+  //   vint8m1x2_t dest = __riscv_vlseg2e8_v_i8m1x2(&ptr[0], 8);
+  //   a_[0].sv64 = __riscv_vget_v_i8m1x2_i8m1(dest, 0);
+  //   a_[1].sv64 = __riscv_vget_v_i8m1x2_i8m1(dest, 1);
+  //   simde_int8x8x2_t r = { {
+  //     simde_int8x8_from_private(a_[0]),
+  //     simde_int8x8_from_private(a_[1]),
+  //   } };
+  //   return r;
   #elif SIMDE_NATURAL_VECTOR_SIZE_GE(128) && defined(SIMDE_SHUFFLE_VECTOR_)
     simde_int8x16_private a_ = simde_int8x16_to_private(simde_vld1q_s8(ptr));
     a_.values = SIMDE_SHUFFLE_VECTOR_(8, 16, a_.values, a_.values, 0, 2, 4, 6, 8, 10, 12, 14, 1, 3, 5, 7, 9, 11, 13, 15);
@@ -93,6 +104,16 @@ simde_int16x4x2_t
 simde_vld2_s16(int16_t const ptr[HEDLEY_ARRAY_PARAM(8)]) {
   #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
     return vld2_s16(ptr);
+  #elif defined(SIMDE_RISCV_V_NATIVE) && (SIMDE_NATURAL_VECTOR_SIZE >= 128)
+    simde_int16x4_private a_[2];
+    vint16mf2x2_t dest = __riscv_vlseg2e16_v_i16mf2x2(&ptr[0], 4);
+    a_[0].sv64 = __riscv_vget_v_i16mf2x2_i16mf2(dest, 0);
+    a_[1].sv64 = __riscv_vget_v_i16mf2x2_i16mf2(dest, 1);
+    simde_int16x4x2_t r = { {
+      simde_int16x4_from_private(a_[0]),
+      simde_int16x4_from_private(a_[1]),
+    } };
+    return r;
   #elif SIMDE_NATURAL_VECTOR_SIZE_GE(128) && defined(SIMDE_SHUFFLE_VECTOR_)
     simde_int16x8_private a_ = simde_int16x8_to_private(simde_vld1q_s16(ptr));
     a_.values = SIMDE_SHUFFLE_VECTOR_(16, 16, a_.values, a_.values, 0, 2, 4, 6, 1, 3, 5, 7);
@@ -133,6 +154,16 @@ simde_int32x2x2_t
 simde_vld2_s32(int32_t const ptr[HEDLEY_ARRAY_PARAM(4)]) {
   #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
     return vld2_s32(ptr);
+  #elif defined(SIMDE_RISCV_V_NATIVE) && (SIMDE_NATURAL_VECTOR_SIZE >= 128)
+    simde_int32x2_private a_[2];
+    vint32mf2x2_t dest = __riscv_vlseg2e32_v_i32mf2x2(&ptr[0], 2);
+    a_[0].sv64 = __riscv_vget_v_i32mf2x2_i32mf2(dest, 0);
+    a_[1].sv64 = __riscv_vget_v_i32mf2x2_i32mf2(dest, 1);
+    simde_int32x2x2_t r = { {
+      simde_int32x2_from_private(a_[0]),
+      simde_int32x2_from_private(a_[1]),
+    } };
+    return r;
   #elif SIMDE_NATURAL_VECTOR_SIZE_GE(128) && defined(SIMDE_SHUFFLE_VECTOR_)
     simde_int32x4_private a_ = simde_int32x4_to_private(simde_vld1q_s32(ptr));
     a_.values = SIMDE_SHUFFLE_VECTOR_(32, 16, a_.values, a_.values, 0, 2, 1, 3);
@@ -166,6 +197,16 @@ simde_int64x1x2_t
 simde_vld2_s64(int64_t const ptr[HEDLEY_ARRAY_PARAM(2)]) {
   #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
     return vld2_s64(ptr);
+  #elif defined(SIMDE_RISCV_V_NATIVE) && (SIMDE_NATURAL_VECTOR_SIZE >= 128)
+    simde_int64x1_private a_[2];
+    vint64m1x2_t dest = __riscv_vlseg2e64_v_i64m1x2(&ptr[0], 1);
+    a_[0].sv64 = __riscv_vget_v_i64m1x2_i64m1(dest, 0);
+    a_[1].sv64 = __riscv_vget_v_i64m1x2_i64m1(dest, 1);
+    simde_int64x1x2_t r = { {
+      simde_int64x1_from_private(a_[0]),
+      simde_int64x1_from_private(a_[1]),
+    } };
+    return r;
   #elif SIMDE_NATURAL_VECTOR_SIZE_GE(128) && defined(SIMDE_SHUFFLE_VECTOR_)
     simde_int64x2_private a_ = simde_int64x2_to_private(simde_vld1q_s64(ptr));
     a_.values = SIMDE_SHUFFLE_VECTOR_(64, 16, a_.values, a_.values, 0, 1);
@@ -210,6 +251,16 @@ simde_vld2_u8(uint8_t const ptr[HEDLEY_ARRAY_PARAM(16)]) {
       simde_vget_high_u8(q)
     };
     return u;
+  #elif defined(SIMDE_RISCV_V_NATIVE) && (SIMDE_NATURAL_VECTOR_SIZE >= 128)
+    simde_uint8x8_private a_[2];
+    vuint8mf2x2_t dest = __riscv_vlseg2e8_v_u8mf2x2(&ptr[0], 8);
+    a_[0].sv64 = __riscv_vget_v_u8mf2x2_u8mf2(dest, 0);
+    a_[1].sv64 = __riscv_vget_v_u8mf2x2_u8mf2(dest, 1);
+    simde_uint8x8x2_t r = { {
+      simde_uint8x8_from_private(a_[0]),
+      simde_uint8x8_from_private(a_[1]),
+    } };
+    return r;
   #elif SIMDE_NATURAL_VECTOR_SIZE_GE(128) && defined(SIMDE_SHUFFLE_VECTOR_)
     simde_uint8x16_private a_ = simde_uint8x16_to_private(simde_vld1q_u8(ptr));
     a_.values = SIMDE_SHUFFLE_VECTOR_(8, 16, a_.values, a_.values, 0, 2, 4, 6, 8, 10, 12, 14, 1, 3, 5, 7, 9, 11, 13, 15);
@@ -243,6 +294,16 @@ simde_uint16x4x2_t
 simde_vld2_u16(uint16_t const ptr[HEDLEY_ARRAY_PARAM(8)]) {
   #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
     return vld2_u16(ptr);
+  #elif defined(SIMDE_RISCV_V_NATIVE) && (SIMDE_NATURAL_VECTOR_SIZE >= 128)
+    simde_uint16x4_private a_[2];
+    vuint16mf2x2_t dest = __riscv_vlseg2e16_v_u16mf2x2(&ptr[0], 4);
+    a_[0].sv64 = __riscv_vget_v_u16mf2x2_u16mf2(dest, 0);
+    a_[1].sv64 = __riscv_vget_v_u16mf2x2_u16mf2(dest, 1);
+    simde_uint16x4x2_t r = { {
+      simde_uint16x4_from_private(a_[0]),
+      simde_uint16x4_from_private(a_[1]),
+    } };
+    return r;
   #elif SIMDE_NATURAL_VECTOR_SIZE_GE(128) && defined(SIMDE_SHUFFLE_VECTOR_)
     simde_uint16x8_private a_ = simde_uint16x8_to_private(simde_vld1q_u16(ptr));
     a_.values = SIMDE_SHUFFLE_VECTOR_(16, 16, a_.values, a_.values, 0, 2, 4, 6, 1, 3, 5, 7);
@@ -283,6 +344,16 @@ simde_uint32x2x2_t
 simde_vld2_u32(uint32_t const ptr[HEDLEY_ARRAY_PARAM(4)]) {
   #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
     return vld2_u32(ptr);
+  #elif defined(SIMDE_RISCV_V_NATIVE) && (SIMDE_NATURAL_VECTOR_SIZE >= 128)
+    simde_uint32x2_private a_[2];
+    vuint32mf2x2_t dest = __riscv_vlseg2e32_v_u32mf2x2(&ptr[0], 2);
+    a_[0].sv64 = __riscv_vget_v_u32mf2x2_u32mf2(dest, 0);
+    a_[1].sv64 = __riscv_vget_v_u32mf2x2_u32mf2(dest, 1);
+    simde_uint32x2x2_t r = { {
+      simde_uint32x2_from_private(a_[0]),
+      simde_uint32x2_from_private(a_[1]),
+    } };
+    return r;
   #elif SIMDE_NATURAL_VECTOR_SIZE_GE(128) && defined(SIMDE_SHUFFLE_VECTOR_)
     simde_uint32x4_private a_ = simde_uint32x4_to_private(simde_vld1q_u32(ptr));
     a_.values = SIMDE_SHUFFLE_VECTOR_(32, 16, a_.values, a_.values, 0, 2, 1, 3);
@@ -316,6 +387,16 @@ simde_uint64x1x2_t
 simde_vld2_u64(uint64_t const ptr[HEDLEY_ARRAY_PARAM(2)]) {
   #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
     return vld2_u64(ptr);
+  #elif defined(SIMDE_RISCV_V_NATIVE) && (SIMDE_NATURAL_VECTOR_SIZE >= 128)
+    simde_uint64x1_private a_[2];
+    vuint64m1x2_t dest = __riscv_vlseg2e64_v_u64m1x2(&ptr[0], 1);
+    a_[0].sv64 = __riscv_vget_v_u64m1x2_u64m1(dest, 0);
+    a_[1].sv64 = __riscv_vget_v_u64m1x2_u64m1(dest, 1);
+    simde_uint64x1x2_t r = { {
+      simde_uint64x1_from_private(a_[0]),
+      simde_uint64x1_from_private(a_[1]),
+    } };
+    return r;
   #elif SIMDE_NATURAL_VECTOR_SIZE_GE(128) && defined(SIMDE_SHUFFLE_VECTOR_)
     simde_uint64x2_private a_ = simde_uint64x2_to_private(simde_vld1q_u64(ptr));
     a_.values = SIMDE_SHUFFLE_VECTOR_(64, 16, a_.values, a_.values, 0, 1);
@@ -349,6 +430,16 @@ simde_float16x4x2_t
 simde_vld2_f16(simde_float16_t const ptr[HEDLEY_ARRAY_PARAM(8)]) {
   #if defined(SIMDE_ARM_NEON_A32V7_NATIVE) && defined(SIMDE_ARM_NEON_FP16)
     return vld2_f16(ptr);
+  #elif defined(SIMDE_RISCV_V_NATIVE) && SIMDE_ARCH_RISCV_ZVFH && (SIMDE_NATURAL_VECTOR_SIZE >= 128)
+    simde_float16x4_private r_[2];
+    vfloat16mf2x2_t dest = __riscv_vlseg2e16_v_f16mf2x2((_Float16 *)&ptr[0], 4);
+    r_[0].sv64 = __riscv_vget_v_f16mf2x2_f16mf2(dest, 0);
+    r_[1].sv64 = __riscv_vget_v_f16mf2x2_f16mf2(dest, 1);
+    simde_float16x4x2_t r = { {
+      simde_float16x4_from_private(r_[0]),
+      simde_float16x4_from_private(r_[1]),
+    } };
+    return r;
   #else
     simde_float16x4_private r_[2];
 
@@ -376,6 +467,16 @@ simde_float32x2x2_t
 simde_vld2_f32(simde_float32_t const ptr[HEDLEY_ARRAY_PARAM(4)]) {
   #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
     return vld2_f32(ptr);
+  #elif defined(SIMDE_RISCV_V_NATIVE) && (SIMDE_NATURAL_VECTOR_SIZE >= 128)
+    simde_float32x2_private r_[2];
+    vfloat32mf2x2_t dest = __riscv_vlseg2e32_v_f32mf2x2(&ptr[0], 2);
+    r_[0].sv64 = __riscv_vget_v_f32mf2x2_f32mf2(dest, 0);
+    r_[1].sv64 = __riscv_vget_v_f32mf2x2_f32mf2(dest, 1);
+    simde_float32x2x2_t r = { {
+      simde_float32x2_from_private(r_[0]),
+      simde_float32x2_from_private(r_[1]),
+    } };
+    return r;
   #elif SIMDE_NATURAL_VECTOR_SIZE_GE(128) && defined(SIMDE_SHUFFLE_VECTOR_)
     simde_float32x4_private a_ = simde_float32x4_to_private(simde_vld1q_f32(ptr));
     a_.values = SIMDE_SHUFFLE_VECTOR_(32, 16, a_.values, a_.values, 0, 2, 1, 3);
@@ -409,6 +510,16 @@ simde_float64x1x2_t
 simde_vld2_f64(simde_float64_t const ptr[HEDLEY_ARRAY_PARAM(2)]) {
   #if defined(SIMDE_ARM_NEON_A64V8_NATIVE)
     return vld2_f64(ptr);
+  #elif defined(SIMDE_RISCV_V_NATIVE) && (SIMDE_NATURAL_VECTOR_SIZE >= 128)
+    simde_float64x1_private r_[2];
+    vfloat64m1x2_t dest = __riscv_vlseg2e64_v_f64m1x2(&ptr[0], 1);
+    r_[0].sv64 = __riscv_vget_v_f64m1x2_f64m1(dest, 0);
+    r_[1].sv64 = __riscv_vget_v_f64m1x2_f64m1(dest, 1);
+    simde_float64x1x2_t r = { {
+      simde_float64x1_from_private(r_[0]),
+      simde_float64x1_from_private(r_[1]),
+    } };
+    return r;
   #elif SIMDE_NATURAL_VECTOR_SIZE_GE(128) && defined(SIMDE_SHUFFLE_VECTOR_)
     simde_float64x2_private a_ = simde_float64x2_to_private(simde_vld1q_f64(ptr));
     a_.values = SIMDE_SHUFFLE_VECTOR_(64, 16, a_.values, a_.values, 0, 1);
@@ -442,6 +553,16 @@ simde_int8x16x2_t
 simde_vld2q_s8(int8_t const ptr[HEDLEY_ARRAY_PARAM(32)]) {
   #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
     return vld2q_s8(ptr);
+  #elif defined(SIMDE_RISCV_V_NATIVE) && (SIMDE_NATURAL_VECTOR_SIZE >= 128)
+    simde_int8x16_private a_[2];
+    vint8m1x2_t dest = __riscv_vlseg2e8_v_i8m1x2(&ptr[0], 16);
+    a_[0].sv128 = __riscv_vget_v_i8m1x2_i8m1(dest, 0);
+    a_[1].sv128 = __riscv_vget_v_i8m1x2_i8m1(dest, 1);
+    simde_int8x16x2_t r = { {
+      simde_int8x16_from_private(a_[0]),
+      simde_int8x16_from_private(a_[1]),
+    } };
+    return r;
   #elif SIMDE_NATURAL_VECTOR_SIZE_GE(128)
     return
       simde_vuzpq_s8(
@@ -475,6 +596,16 @@ simde_int32x4x2_t
 simde_vld2q_s32(int32_t const ptr[HEDLEY_ARRAY_PARAM(8)]) {
   #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
     return vld2q_s32(ptr);
+  #elif defined(SIMDE_RISCV_V_NATIVE) && (SIMDE_NATURAL_VECTOR_SIZE >= 128)
+    simde_int32x4_private a_[2];
+    vint32m1x2_t dest = __riscv_vlseg2e32_v_i32m1x2(&ptr[0], 4);
+    a_[0].sv128 = __riscv_vget_v_i32m1x2_i32m1(dest, 0);
+    a_[1].sv128 = __riscv_vget_v_i32m1x2_i32m1(dest, 1);
+    simde_int32x4x2_t r = { {
+      simde_int32x4_from_private(a_[0]),
+      simde_int32x4_from_private(a_[1]),
+    } };
+    return r;
   #elif SIMDE_NATURAL_VECTOR_SIZE_GE(128)
     return
       simde_vuzpq_s32(
@@ -515,6 +646,16 @@ simde_int16x8x2_t
 simde_vld2q_s16(int16_t const ptr[HEDLEY_ARRAY_PARAM(16)]) {
   #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
     return vld2q_s16(ptr);
+  #elif defined(SIMDE_RISCV_V_NATIVE) && (SIMDE_NATURAL_VECTOR_SIZE >= 128)
+    simde_int16x8_private r_[2];
+    vint16m1x2_t dest = __riscv_vlseg2e16_v_i16m1x2(&ptr[0], 8);
+    r_[0].sv128 = __riscv_vget_v_i16m1x2_i16m1(dest, 0);
+    r_[1].sv128 = __riscv_vget_v_i16m1x2_i16m1(dest, 1);
+    simde_int16x8x2_t r = { {
+      simde_int16x8_from_private(r_[0]),
+      simde_int16x8_from_private(r_[1]),
+    } };
+    return r;
   #elif SIMDE_NATURAL_VECTOR_SIZE_GE(128)
     return
       simde_vuzpq_s16(
@@ -548,6 +689,16 @@ simde_int64x2x2_t
 simde_vld2q_s64(int64_t const ptr[HEDLEY_ARRAY_PARAM(4)]) {
   #if defined(SIMDE_ARM_NEON_A64V8_NATIVE)
     return vld2q_s64(ptr);
+  #elif defined(SIMDE_RISCV_V_NATIVE) && (SIMDE_NATURAL_VECTOR_SIZE >= 128)
+    simde_int64x2_private r_[2];
+    vint64m1x2_t dest = __riscv_vlseg2e64_v_i64m1x2(&ptr[0], 2);
+    r_[0].sv128 = __riscv_vget_v_i64m1x2_i64m1(dest, 0);
+    r_[1].sv128 = __riscv_vget_v_i64m1x2_i64m1(dest, 1);
+    simde_int64x2x2_t r = { {
+      simde_int64x2_from_private(r_[0]),
+      simde_int64x2_from_private(r_[1]),
+    } };
+    return r;
   #else
     simde_int64x2_private r_[2];
 
@@ -575,6 +726,16 @@ simde_uint8x16x2_t
 simde_vld2q_u8(uint8_t const ptr[HEDLEY_ARRAY_PARAM(32)]) {
   #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
     return vld2q_u8(ptr);
+  #elif defined(SIMDE_RISCV_V_NATIVE) && (SIMDE_NATURAL_VECTOR_SIZE >= 128)
+    simde_uint8x16_private r_[2];
+    vuint8m1x2_t dest = __riscv_vlseg2e8_v_u8m1x2(&ptr[0], 16);
+    r_[0].sv128 = __riscv_vget_v_u8m1x2_u8m1(dest, 0);
+    r_[1].sv128 = __riscv_vget_v_u8m1x2_u8m1(dest, 1);
+    simde_uint8x16x2_t r = { {
+      simde_uint8x16_from_private(r_[0]),
+      simde_uint8x16_from_private(r_[1]),
+    } };
+    return r;
   #elif SIMDE_NATURAL_VECTOR_SIZE_GE(128)
     return
       simde_vuzpq_u8(
@@ -608,6 +769,16 @@ simde_uint16x8x2_t
 simde_vld2q_u16(uint16_t const ptr[HEDLEY_ARRAY_PARAM(16)]) {
   #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
     return vld2q_u16(ptr);
+  #elif defined(SIMDE_RISCV_V_NATIVE) && (SIMDE_NATURAL_VECTOR_SIZE >= 128)
+    simde_uint16x8_private r_[2];
+    vuint16m1x2_t dest = __riscv_vlseg2e16_v_u16m1x2(&ptr[0], 8);
+    r_[0].sv128 = __riscv_vget_v_u16m1x2_u16m1(dest, 0);
+    r_[1].sv128 = __riscv_vget_v_u16m1x2_u16m1(dest, 1);
+    simde_uint16x8x2_t r = { {
+      simde_uint16x8_from_private(r_[0]),
+      simde_uint16x8_from_private(r_[1]),
+    } };
+    return r;
   #elif SIMDE_NATURAL_VECTOR_SIZE_GE(128)
     return
       simde_vuzpq_u16(
@@ -641,6 +812,16 @@ simde_uint32x4x2_t
 simde_vld2q_u32(uint32_t const ptr[HEDLEY_ARRAY_PARAM(8)]) {
   #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
     return vld2q_u32(ptr);
+  #elif defined(SIMDE_RISCV_V_NATIVE) && (SIMDE_NATURAL_VECTOR_SIZE >= 128)
+    simde_uint32x4_private r_[2];
+    vuint32m1x2_t dest = __riscv_vlseg2e32_v_u32m1x2(&ptr[0], 4);
+    r_[0].sv128 = __riscv_vget_v_u32m1x2_u32m1(dest, 0);
+    r_[1].sv128 = __riscv_vget_v_u32m1x2_u32m1(dest, 1);
+    simde_uint32x4x2_t r = { {
+      simde_uint32x4_from_private(r_[0]),
+      simde_uint32x4_from_private(r_[1]),
+    } };
+    return r;
   #elif SIMDE_NATURAL_VECTOR_SIZE_GE(128)
     return
       simde_vuzpq_u32(
@@ -681,6 +862,16 @@ simde_uint64x2x2_t
 simde_vld2q_u64(uint64_t const ptr[HEDLEY_ARRAY_PARAM(4)]) {
   #if defined(SIMDE_ARM_NEON_A64V8_NATIVE)
     return vld2q_u64(ptr);
+  #elif defined(SIMDE_RISCV_V_NATIVE) && (SIMDE_NATURAL_VECTOR_SIZE >= 128)
+    simde_uint64x2_private r_[2];
+    vuint64m1x2_t dest = __riscv_vlseg2e64_v_u64m1x2(&ptr[0], 2);
+    r_[0].sv128 = __riscv_vget_v_u64m1x2_u64m1(dest, 0);
+    r_[1].sv128 = __riscv_vget_v_u64m1x2_u64m1(dest, 1);
+    simde_uint64x2x2_t r = { {
+      simde_uint64x2_from_private(r_[0]),
+      simde_uint64x2_from_private(r_[1]),
+    } };
+    return r;
   #else
     simde_uint64x2_private r_[2];
 
@@ -708,6 +899,16 @@ simde_float16x8x2_t
 simde_vld2q_f16(simde_float16_t const ptr[HEDLEY_ARRAY_PARAM(16)]) {
   #if defined(SIMDE_ARM_NEON_A32V7_NATIVE) && defined(SIMDE_ARM_NEON_FP16)
     return vld2q_f16(ptr);
+  #elif defined(SIMDE_RISCV_V_NATIVE) && SIMDE_ARCH_RISCV_ZVFH && (SIMDE_NATURAL_VECTOR_SIZE >= 128)
+    simde_float16x8_private r_[2];
+    vfloat16m1x2_t dest = __riscv_vlseg2e16_v_f16m1x2((_Float16 *)&ptr[0], 8);
+    r_[0].sv128 = __riscv_vget_v_f16m1x2_f16m1(dest, 0);
+    r_[1].sv128 = __riscv_vget_v_f16m1x2_f16m1(dest, 1);
+    simde_float16x8x2_t r = { {
+      simde_float16x8_from_private(r_[0]),
+      simde_float16x8_from_private(r_[1]),
+    } };
+    return r;
   #else
     #if defined(SIMDE_DIAGNOSTIC_DISABLE_UNINITIALIZED_) && HEDLEY_GCC_VERSION_CHECK(12,0,0)
       HEDLEY_DIAGNOSTIC_PUSH
@@ -742,6 +943,16 @@ simde_float32x4x2_t
 simde_vld2q_f32(simde_float32_t const ptr[HEDLEY_ARRAY_PARAM(8)]) {
   #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
     return vld2q_f32(ptr);
+  #elif defined(SIMDE_RISCV_V_NATIVE) && (SIMDE_NATURAL_VECTOR_SIZE >= 128)
+    simde_float32x4_private r_[2];
+    vfloat32m1x2_t dest = __riscv_vlseg2e32_v_f32m1x2(&ptr[0], 4);
+    r_[0].sv128 = __riscv_vget_v_f32m1x2_f32m1(dest, 0);
+    r_[1].sv128 = __riscv_vget_v_f32m1x2_f32m1(dest, 1);
+    simde_float32x4x2_t r = { {
+      simde_float32x4_from_private(r_[0]),
+      simde_float32x4_from_private(r_[1]),
+    } };
+    return r;
   #elif SIMDE_NATURAL_VECTOR_SIZE_GE(128)
     return
       simde_vuzpq_f32(
@@ -782,6 +993,16 @@ simde_float64x2x2_t
 simde_vld2q_f64(simde_float64_t const ptr[HEDLEY_ARRAY_PARAM(4)]) {
   #if defined(SIMDE_ARM_NEON_A64V8_NATIVE)
     return vld2q_f64(ptr);
+  #elif defined(SIMDE_RISCV_V_NATIVE) && (SIMDE_NATURAL_VECTOR_SIZE >= 128)
+    simde_float64x2_private r_[2];
+    vfloat64m1x2_t dest = __riscv_vlseg2e64_v_f64m1x2(&ptr[0], 2);
+    r_[0].sv128 = __riscv_vget_v_f64m1x2_f64m1(dest, 0);
+    r_[1].sv128 = __riscv_vget_v_f64m1x2_f64m1(dest, 1);
+    simde_float64x2x2_t r = { {
+      simde_float64x2_from_private(r_[0]),
+      simde_float64x2_from_private(r_[1]),
+    } };
+    return r;
   #else
     simde_float64x2_private r_[2];
 

--- a/simde/arm/neon/ld2.h
+++ b/simde/arm/neon/ld2.h
@@ -61,7 +61,7 @@ simde_vld2_s8(int8_t const ptr[HEDLEY_ARRAY_PARAM(16)]) {
       simde_vget_high_s8(q)
     };
     return u;
-  #elif defined(SIMDE_RISCV_V_NATIVE) && (SIMDE_NATURAL_VECTOR_SIZE >= 128)
+  #elif defined(SIMDE_RISCV_V_NATIVE)
     simde_int8x8_private a_[2];
     vint8m1x2_t dest = __riscv_vlseg2e8_v_i8m1x2(&ptr[0], 8);
     a_[0].sv64 = __riscv_vget_v_i8m1x2_i8m1(dest, 0);
@@ -104,7 +104,7 @@ simde_int16x4x2_t
 simde_vld2_s16(int16_t const ptr[HEDLEY_ARRAY_PARAM(8)]) {
   #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
     return vld2_s16(ptr);
-  #elif defined(SIMDE_RISCV_V_NATIVE) && (SIMDE_NATURAL_VECTOR_SIZE >= 128)
+  #elif defined(SIMDE_RISCV_V_NATIVE)
     simde_int16x4_private a_[2];
     vint16m1x2_t dest = __riscv_vlseg2e16_v_i16m1x2(&ptr[0], 4);
     a_[0].sv64 = __riscv_vget_v_i16m1x2_i16m1(dest, 0);
@@ -154,7 +154,7 @@ simde_int32x2x2_t
 simde_vld2_s32(int32_t const ptr[HEDLEY_ARRAY_PARAM(4)]) {
   #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
     return vld2_s32(ptr);
-  #elif defined(SIMDE_RISCV_V_NATIVE) && (SIMDE_NATURAL_VECTOR_SIZE >= 128)
+  #elif defined(SIMDE_RISCV_V_NATIVE)
     simde_int32x2_private a_[2];
     vint32m1x2_t dest = __riscv_vlseg2e32_v_i32m1x2(&ptr[0], 2);
     a_[0].sv64 = __riscv_vget_v_i32m1x2_i32m1(dest, 0);
@@ -197,7 +197,7 @@ simde_int64x1x2_t
 simde_vld2_s64(int64_t const ptr[HEDLEY_ARRAY_PARAM(2)]) {
   #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
     return vld2_s64(ptr);
-  #elif defined(SIMDE_RISCV_V_NATIVE) && (SIMDE_NATURAL_VECTOR_SIZE >= 128)
+  #elif defined(SIMDE_RISCV_V_NATIVE)
     simde_int64x1_private a_[2];
     vint64m1x2_t dest = __riscv_vlseg2e64_v_i64m1x2(&ptr[0], 1);
     a_[0].sv64 = __riscv_vget_v_i64m1x2_i64m1(dest, 0);
@@ -251,7 +251,7 @@ simde_vld2_u8(uint8_t const ptr[HEDLEY_ARRAY_PARAM(16)]) {
       simde_vget_high_u8(q)
     };
     return u;
-  #elif defined(SIMDE_RISCV_V_NATIVE) && (SIMDE_NATURAL_VECTOR_SIZE >= 128)
+  #elif defined(SIMDE_RISCV_V_NATIVE)
     simde_uint8x8_private a_[2];
     vuint8m1x2_t dest = __riscv_vlseg2e8_v_u8m1x2(&ptr[0], 8);
     a_[0].sv64 = __riscv_vget_v_u8m1x2_u8m1(dest, 0);
@@ -294,7 +294,7 @@ simde_uint16x4x2_t
 simde_vld2_u16(uint16_t const ptr[HEDLEY_ARRAY_PARAM(8)]) {
   #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
     return vld2_u16(ptr);
-  #elif defined(SIMDE_RISCV_V_NATIVE) && (SIMDE_NATURAL_VECTOR_SIZE >= 128)
+  #elif defined(SIMDE_RISCV_V_NATIVE)
     simde_uint16x4_private a_[2];
     vuint16m1x2_t dest = __riscv_vlseg2e16_v_u16m1x2(&ptr[0], 4);
     a_[0].sv64 = __riscv_vget_v_u16m1x2_u16m1(dest, 0);
@@ -344,7 +344,7 @@ simde_uint32x2x2_t
 simde_vld2_u32(uint32_t const ptr[HEDLEY_ARRAY_PARAM(4)]) {
   #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
     return vld2_u32(ptr);
-  #elif defined(SIMDE_RISCV_V_NATIVE) && (SIMDE_NATURAL_VECTOR_SIZE >= 128)
+  #elif defined(SIMDE_RISCV_V_NATIVE)
     simde_uint32x2_private a_[2];
     vuint32m1x2_t dest = __riscv_vlseg2e32_v_u32m1x2(&ptr[0], 2);
     a_[0].sv64 = __riscv_vget_v_u32m1x2_u32m1(dest, 0);
@@ -387,7 +387,7 @@ simde_uint64x1x2_t
 simde_vld2_u64(uint64_t const ptr[HEDLEY_ARRAY_PARAM(2)]) {
   #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
     return vld2_u64(ptr);
-  #elif defined(SIMDE_RISCV_V_NATIVE) && (SIMDE_NATURAL_VECTOR_SIZE >= 128)
+  #elif defined(SIMDE_RISCV_V_NATIVE)
     simde_uint64x1_private a_[2];
     vuint64m1x2_t dest = __riscv_vlseg2e64_v_u64m1x2(&ptr[0], 1);
     a_[0].sv64 = __riscv_vget_v_u64m1x2_u64m1(dest, 0);
@@ -467,7 +467,7 @@ simde_float32x2x2_t
 simde_vld2_f32(simde_float32_t const ptr[HEDLEY_ARRAY_PARAM(4)]) {
   #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
     return vld2_f32(ptr);
-  #elif defined(SIMDE_RISCV_V_NATIVE) && (SIMDE_NATURAL_VECTOR_SIZE >= 128)
+  #elif defined(SIMDE_RISCV_V_NATIVE)
     simde_float32x2_private r_[2];
     vfloat32m1x2_t dest = __riscv_vlseg2e32_v_f32m1x2(&ptr[0], 2);
     r_[0].sv64 = __riscv_vget_v_f32m1x2_f32m1(dest, 0);
@@ -510,7 +510,7 @@ simde_float64x1x2_t
 simde_vld2_f64(simde_float64_t const ptr[HEDLEY_ARRAY_PARAM(2)]) {
   #if defined(SIMDE_ARM_NEON_A64V8_NATIVE)
     return vld2_f64(ptr);
-  #elif defined(SIMDE_RISCV_V_NATIVE) && (SIMDE_NATURAL_VECTOR_SIZE >= 128)
+  #elif defined(SIMDE_RISCV_V_NATIVE)
     simde_float64x1_private r_[2];
     vfloat64m1x2_t dest = __riscv_vlseg2e64_v_f64m1x2(&ptr[0], 1);
     r_[0].sv64 = __riscv_vget_v_f64m1x2_f64m1(dest, 0);
@@ -553,7 +553,7 @@ simde_int8x16x2_t
 simde_vld2q_s8(int8_t const ptr[HEDLEY_ARRAY_PARAM(32)]) {
   #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
     return vld2q_s8(ptr);
-  #elif defined(SIMDE_RISCV_V_NATIVE) && (SIMDE_NATURAL_VECTOR_SIZE >= 128)
+  #elif defined(SIMDE_RISCV_V_NATIVE)
     simde_int8x16_private a_[2];
     vint8m1x2_t dest = __riscv_vlseg2e8_v_i8m1x2(&ptr[0], 16);
     a_[0].sv128 = __riscv_vget_v_i8m1x2_i8m1(dest, 0);
@@ -596,7 +596,7 @@ simde_int32x4x2_t
 simde_vld2q_s32(int32_t const ptr[HEDLEY_ARRAY_PARAM(8)]) {
   #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
     return vld2q_s32(ptr);
-  #elif defined(SIMDE_RISCV_V_NATIVE) && (SIMDE_NATURAL_VECTOR_SIZE >= 128)
+  #elif defined(SIMDE_RISCV_V_NATIVE)
     simde_int32x4_private a_[2];
     vint32m1x2_t dest = __riscv_vlseg2e32_v_i32m1x2(&ptr[0], 4);
     a_[0].sv128 = __riscv_vget_v_i32m1x2_i32m1(dest, 0);
@@ -646,7 +646,7 @@ simde_int16x8x2_t
 simde_vld2q_s16(int16_t const ptr[HEDLEY_ARRAY_PARAM(16)]) {
   #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
     return vld2q_s16(ptr);
-  #elif defined(SIMDE_RISCV_V_NATIVE) && (SIMDE_NATURAL_VECTOR_SIZE >= 128)
+  #elif defined(SIMDE_RISCV_V_NATIVE)
     simde_int16x8_private r_[2];
     vint16m1x2_t dest = __riscv_vlseg2e16_v_i16m1x2(&ptr[0], 8);
     r_[0].sv128 = __riscv_vget_v_i16m1x2_i16m1(dest, 0);
@@ -689,7 +689,7 @@ simde_int64x2x2_t
 simde_vld2q_s64(int64_t const ptr[HEDLEY_ARRAY_PARAM(4)]) {
   #if defined(SIMDE_ARM_NEON_A64V8_NATIVE)
     return vld2q_s64(ptr);
-  #elif defined(SIMDE_RISCV_V_NATIVE) && (SIMDE_NATURAL_VECTOR_SIZE >= 128)
+  #elif defined(SIMDE_RISCV_V_NATIVE)
     simde_int64x2_private r_[2];
     vint64m1x2_t dest = __riscv_vlseg2e64_v_i64m1x2(&ptr[0], 2);
     r_[0].sv128 = __riscv_vget_v_i64m1x2_i64m1(dest, 0);
@@ -726,7 +726,7 @@ simde_uint8x16x2_t
 simde_vld2q_u8(uint8_t const ptr[HEDLEY_ARRAY_PARAM(32)]) {
   #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
     return vld2q_u8(ptr);
-  #elif defined(SIMDE_RISCV_V_NATIVE) && (SIMDE_NATURAL_VECTOR_SIZE >= 128)
+  #elif defined(SIMDE_RISCV_V_NATIVE)
     simde_uint8x16_private r_[2];
     vuint8m1x2_t dest = __riscv_vlseg2e8_v_u8m1x2(&ptr[0], 16);
     r_[0].sv128 = __riscv_vget_v_u8m1x2_u8m1(dest, 0);
@@ -769,7 +769,7 @@ simde_uint16x8x2_t
 simde_vld2q_u16(uint16_t const ptr[HEDLEY_ARRAY_PARAM(16)]) {
   #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
     return vld2q_u16(ptr);
-  #elif defined(SIMDE_RISCV_V_NATIVE) && (SIMDE_NATURAL_VECTOR_SIZE >= 128)
+  #elif defined(SIMDE_RISCV_V_NATIVE)
     simde_uint16x8_private r_[2];
     vuint16m1x2_t dest = __riscv_vlseg2e16_v_u16m1x2(&ptr[0], 8);
     r_[0].sv128 = __riscv_vget_v_u16m1x2_u16m1(dest, 0);
@@ -812,7 +812,7 @@ simde_uint32x4x2_t
 simde_vld2q_u32(uint32_t const ptr[HEDLEY_ARRAY_PARAM(8)]) {
   #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
     return vld2q_u32(ptr);
-  #elif defined(SIMDE_RISCV_V_NATIVE) && (SIMDE_NATURAL_VECTOR_SIZE >= 128)
+  #elif defined(SIMDE_RISCV_V_NATIVE)
     simde_uint32x4_private r_[2];
     vuint32m1x2_t dest = __riscv_vlseg2e32_v_u32m1x2(&ptr[0], 4);
     r_[0].sv128 = __riscv_vget_v_u32m1x2_u32m1(dest, 0);
@@ -862,7 +862,7 @@ simde_uint64x2x2_t
 simde_vld2q_u64(uint64_t const ptr[HEDLEY_ARRAY_PARAM(4)]) {
   #if defined(SIMDE_ARM_NEON_A64V8_NATIVE)
     return vld2q_u64(ptr);
-  #elif defined(SIMDE_RISCV_V_NATIVE) && (SIMDE_NATURAL_VECTOR_SIZE >= 128)
+  #elif defined(SIMDE_RISCV_V_NATIVE)
     simde_uint64x2_private r_[2];
     vuint64m1x2_t dest = __riscv_vlseg2e64_v_u64m1x2(&ptr[0], 2);
     r_[0].sv128 = __riscv_vget_v_u64m1x2_u64m1(dest, 0);
@@ -943,7 +943,7 @@ simde_float32x4x2_t
 simde_vld2q_f32(simde_float32_t const ptr[HEDLEY_ARRAY_PARAM(8)]) {
   #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
     return vld2q_f32(ptr);
-  #elif defined(SIMDE_RISCV_V_NATIVE) && (SIMDE_NATURAL_VECTOR_SIZE >= 128)
+  #elif defined(SIMDE_RISCV_V_NATIVE)
     simde_float32x4_private r_[2];
     vfloat32m1x2_t dest = __riscv_vlseg2e32_v_f32m1x2(&ptr[0], 4);
     r_[0].sv128 = __riscv_vget_v_f32m1x2_f32m1(dest, 0);
@@ -993,7 +993,7 @@ simde_float64x2x2_t
 simde_vld2q_f64(simde_float64_t const ptr[HEDLEY_ARRAY_PARAM(4)]) {
   #if defined(SIMDE_ARM_NEON_A64V8_NATIVE)
     return vld2q_f64(ptr);
-  #elif defined(SIMDE_RISCV_V_NATIVE) && (SIMDE_NATURAL_VECTOR_SIZE >= 128)
+  #elif defined(SIMDE_RISCV_V_NATIVE)
     simde_float64x2_private r_[2];
     vfloat64m1x2_t dest = __riscv_vlseg2e64_v_f64m1x2(&ptr[0], 2);
     r_[0].sv128 = __riscv_vget_v_f64m1x2_f64m1(dest, 0);

--- a/simde/arm/neon/ld2.h
+++ b/simde/arm/neon/ld2.h
@@ -63,9 +63,9 @@ simde_vld2_s8(int8_t const ptr[HEDLEY_ARRAY_PARAM(16)]) {
     return u;
   #elif defined(SIMDE_RISCV_V_NATIVE) && (SIMDE_NATURAL_VECTOR_SIZE >= 128)
     simde_int8x8_private a_[2];
-    vint8mf2x2_t dest = __riscv_vlseg2e8_v_i8mf2x2(&ptr[0], 8);
-    a_[0].sv64 = __riscv_vget_v_i8mf2x2_i8mf2(dest, 0);
-    a_[1].sv64 = __riscv_vget_v_i8mf2x2_i8mf2(dest, 1);
+    vint8m1x2_t dest = __riscv_vlseg2e8_v_i8m1x2(&ptr[0], 8);
+    a_[0].sv64 = __riscv_vget_v_i8m1x2_i8m1(dest, 0);
+    a_[1].sv64 = __riscv_vget_v_i8m1x2_i8m1(dest, 1);
     simde_int8x8x2_t r = { {
       simde_int8x8_from_private(a_[0]),
       simde_int8x8_from_private(a_[1]),
@@ -106,9 +106,9 @@ simde_vld2_s16(int16_t const ptr[HEDLEY_ARRAY_PARAM(8)]) {
     return vld2_s16(ptr);
   #elif defined(SIMDE_RISCV_V_NATIVE) && (SIMDE_NATURAL_VECTOR_SIZE >= 128)
     simde_int16x4_private a_[2];
-    vint16mf2x2_t dest = __riscv_vlseg2e16_v_i16mf2x2(&ptr[0], 4);
-    a_[0].sv64 = __riscv_vget_v_i16mf2x2_i16mf2(dest, 0);
-    a_[1].sv64 = __riscv_vget_v_i16mf2x2_i16mf2(dest, 1);
+    vint16m1x2_t dest = __riscv_vlseg2e16_v_i16m1x2(&ptr[0], 4);
+    a_[0].sv64 = __riscv_vget_v_i16m1x2_i16m1(dest, 0);
+    a_[1].sv64 = __riscv_vget_v_i16m1x2_i16m1(dest, 1);
     simde_int16x4x2_t r = { {
       simde_int16x4_from_private(a_[0]),
       simde_int16x4_from_private(a_[1]),
@@ -156,9 +156,9 @@ simde_vld2_s32(int32_t const ptr[HEDLEY_ARRAY_PARAM(4)]) {
     return vld2_s32(ptr);
   #elif defined(SIMDE_RISCV_V_NATIVE) && (SIMDE_NATURAL_VECTOR_SIZE >= 128)
     simde_int32x2_private a_[2];
-    vint32mf2x2_t dest = __riscv_vlseg2e32_v_i32mf2x2(&ptr[0], 2);
-    a_[0].sv64 = __riscv_vget_v_i32mf2x2_i32mf2(dest, 0);
-    a_[1].sv64 = __riscv_vget_v_i32mf2x2_i32mf2(dest, 1);
+    vint32m1x2_t dest = __riscv_vlseg2e32_v_i32m1x2(&ptr[0], 2);
+    a_[0].sv64 = __riscv_vget_v_i32m1x2_i32m1(dest, 0);
+    a_[1].sv64 = __riscv_vget_v_i32m1x2_i32m1(dest, 1);
     simde_int32x2x2_t r = { {
       simde_int32x2_from_private(a_[0]),
       simde_int32x2_from_private(a_[1]),
@@ -253,9 +253,9 @@ simde_vld2_u8(uint8_t const ptr[HEDLEY_ARRAY_PARAM(16)]) {
     return u;
   #elif defined(SIMDE_RISCV_V_NATIVE) && (SIMDE_NATURAL_VECTOR_SIZE >= 128)
     simde_uint8x8_private a_[2];
-    vuint8mf2x2_t dest = __riscv_vlseg2e8_v_u8mf2x2(&ptr[0], 8);
-    a_[0].sv64 = __riscv_vget_v_u8mf2x2_u8mf2(dest, 0);
-    a_[1].sv64 = __riscv_vget_v_u8mf2x2_u8mf2(dest, 1);
+    vuint8m1x2_t dest = __riscv_vlseg2e8_v_u8m1x2(&ptr[0], 8);
+    a_[0].sv64 = __riscv_vget_v_u8m1x2_u8m1(dest, 0);
+    a_[1].sv64 = __riscv_vget_v_u8m1x2_u8m1(dest, 1);
     simde_uint8x8x2_t r = { {
       simde_uint8x8_from_private(a_[0]),
       simde_uint8x8_from_private(a_[1]),
@@ -296,9 +296,9 @@ simde_vld2_u16(uint16_t const ptr[HEDLEY_ARRAY_PARAM(8)]) {
     return vld2_u16(ptr);
   #elif defined(SIMDE_RISCV_V_NATIVE) && (SIMDE_NATURAL_VECTOR_SIZE >= 128)
     simde_uint16x4_private a_[2];
-    vuint16mf2x2_t dest = __riscv_vlseg2e16_v_u16mf2x2(&ptr[0], 4);
-    a_[0].sv64 = __riscv_vget_v_u16mf2x2_u16mf2(dest, 0);
-    a_[1].sv64 = __riscv_vget_v_u16mf2x2_u16mf2(dest, 1);
+    vuint16m1x2_t dest = __riscv_vlseg2e16_v_u16m1x2(&ptr[0], 4);
+    a_[0].sv64 = __riscv_vget_v_u16m1x2_u16m1(dest, 0);
+    a_[1].sv64 = __riscv_vget_v_u16m1x2_u16m1(dest, 1);
     simde_uint16x4x2_t r = { {
       simde_uint16x4_from_private(a_[0]),
       simde_uint16x4_from_private(a_[1]),
@@ -346,9 +346,9 @@ simde_vld2_u32(uint32_t const ptr[HEDLEY_ARRAY_PARAM(4)]) {
     return vld2_u32(ptr);
   #elif defined(SIMDE_RISCV_V_NATIVE) && (SIMDE_NATURAL_VECTOR_SIZE >= 128)
     simde_uint32x2_private a_[2];
-    vuint32mf2x2_t dest = __riscv_vlseg2e32_v_u32mf2x2(&ptr[0], 2);
-    a_[0].sv64 = __riscv_vget_v_u32mf2x2_u32mf2(dest, 0);
-    a_[1].sv64 = __riscv_vget_v_u32mf2x2_u32mf2(dest, 1);
+    vuint32m1x2_t dest = __riscv_vlseg2e32_v_u32m1x2(&ptr[0], 2);
+    a_[0].sv64 = __riscv_vget_v_u32m1x2_u32m1(dest, 0);
+    a_[1].sv64 = __riscv_vget_v_u32m1x2_u32m1(dest, 1);
     simde_uint32x2x2_t r = { {
       simde_uint32x2_from_private(a_[0]),
       simde_uint32x2_from_private(a_[1]),
@@ -432,9 +432,9 @@ simde_vld2_f16(simde_float16_t const ptr[HEDLEY_ARRAY_PARAM(8)]) {
     return vld2_f16(ptr);
   #elif defined(SIMDE_RISCV_V_NATIVE) && SIMDE_ARCH_RISCV_ZVFH && (SIMDE_NATURAL_VECTOR_SIZE >= 128)
     simde_float16x4_private r_[2];
-    vfloat16mf2x2_t dest = __riscv_vlseg2e16_v_f16mf2x2((_Float16 *)&ptr[0], 4);
-    r_[0].sv64 = __riscv_vget_v_f16mf2x2_f16mf2(dest, 0);
-    r_[1].sv64 = __riscv_vget_v_f16mf2x2_f16mf2(dest, 1);
+    vfloat16m1x2_t dest = __riscv_vlseg2e16_v_f16m1x2((_Float16 *)&ptr[0], 4);
+    r_[0].sv64 = __riscv_vget_v_f16m1x2_f16m1(dest, 0);
+    r_[1].sv64 = __riscv_vget_v_f16m1x2_f16m1(dest, 1);
     simde_float16x4x2_t r = { {
       simde_float16x4_from_private(r_[0]),
       simde_float16x4_from_private(r_[1]),
@@ -469,9 +469,9 @@ simde_vld2_f32(simde_float32_t const ptr[HEDLEY_ARRAY_PARAM(4)]) {
     return vld2_f32(ptr);
   #elif defined(SIMDE_RISCV_V_NATIVE) && (SIMDE_NATURAL_VECTOR_SIZE >= 128)
     simde_float32x2_private r_[2];
-    vfloat32mf2x2_t dest = __riscv_vlseg2e32_v_f32mf2x2(&ptr[0], 2);
-    r_[0].sv64 = __riscv_vget_v_f32mf2x2_f32mf2(dest, 0);
-    r_[1].sv64 = __riscv_vget_v_f32mf2x2_f32mf2(dest, 1);
+    vfloat32m1x2_t dest = __riscv_vlseg2e32_v_f32m1x2(&ptr[0], 2);
+    r_[0].sv64 = __riscv_vget_v_f32m1x2_f32m1(dest, 0);
+    r_[1].sv64 = __riscv_vget_v_f32m1x2_f32m1(dest, 1);
     simde_float32x2x2_t r = { {
       simde_float32x2_from_private(r_[0]),
       simde_float32x2_from_private(r_[1]),

--- a/simde/arm/neon/ld2.h
+++ b/simde/arm/neon/ld2.h
@@ -61,16 +61,16 @@ simde_vld2_s8(int8_t const ptr[HEDLEY_ARRAY_PARAM(16)]) {
       simde_vget_high_s8(q)
     };
     return u;
-  // #elif defined(SIMDE_RISCV_V_NATIVE) && (SIMDE_NATURAL_VECTOR_SIZE >= 128)
-  //   simde_int8x8_private a_[2];
-  //   vint8m1x2_t dest = __riscv_vlseg2e8_v_i8m1x2(&ptr[0], 8);
-  //   a_[0].sv64 = __riscv_vget_v_i8m1x2_i8m1(dest, 0);
-  //   a_[1].sv64 = __riscv_vget_v_i8m1x2_i8m1(dest, 1);
-  //   simde_int8x8x2_t r = { {
-  //     simde_int8x8_from_private(a_[0]),
-  //     simde_int8x8_from_private(a_[1]),
-  //   } };
-  //   return r;
+  #elif defined(SIMDE_RISCV_V_NATIVE) && (SIMDE_NATURAL_VECTOR_SIZE >= 128)
+    simde_int8x8_private a_[2];
+    vint8mf2x2_t dest = __riscv_vlseg2e8_v_i8mf2x2(&ptr[0], 8);
+    a_[0].sv64 = __riscv_vget_v_i8mf2x2_i8mf2(dest, 0);
+    a_[1].sv64 = __riscv_vget_v_i8mf2x2_i8mf2(dest, 1);
+    simde_int8x8x2_t r = { {
+      simde_int8x8_from_private(a_[0]),
+      simde_int8x8_from_private(a_[1]),
+    } };
+    return r;
   #elif SIMDE_NATURAL_VECTOR_SIZE_GE(128) && defined(SIMDE_SHUFFLE_VECTOR_)
     simde_int8x16_private a_ = simde_int8x16_to_private(simde_vld1q_s8(ptr));
     a_.values = SIMDE_SHUFFLE_VECTOR_(8, 16, a_.values, a_.values, 0, 2, 4, 6, 8, 10, 12, 14, 1, 3, 5, 7, 9, 11, 13, 15);

--- a/simde/arm/neon/ld3.h
+++ b/simde/arm/neon/ld3.h
@@ -50,10 +50,10 @@ simde_vld3_f16(simde_float16 const *ptr) {
   #else
     simde_float16x4_private r_[3];
     #if defined(SIMDE_RISCV_V_NATIVE) && SIMDE_ARCH_RISCV_ZVFH && (SIMDE_NATURAL_VECTOR_SIZE >= 128)
-      vfloat16mf2x3_t dest = __riscv_vlseg3e16_v_f16mf2x3((_Float16 *)&ptr[0], 4);
-      r_[0].sv64 = __riscv_vget_v_f16mf2x3_f16mf2(dest, 0);
-      r_[1].sv64 = __riscv_vget_v_f16mf2x3_f16mf2(dest, 1);
-      r_[2].sv64 = __riscv_vget_v_f16mf2x3_f16mf2(dest, 2);
+      vfloat16m1x3_t dest = __riscv_vlseg3e16_v_f16m1x3((_Float16 *)&ptr[0], 4);
+      r_[0].sv64 = __riscv_vget_v_f16m1x3_f16m1(dest, 0);
+      r_[1].sv64 = __riscv_vget_v_f16m1x3_f16m1(dest, 1);
+      r_[2].sv64 = __riscv_vget_v_f16m1x3_f16m1(dest, 2);
     #else
       for (size_t i = 0; i < (sizeof(r_) / sizeof(r_[0])); i++) {
         for (size_t j = 0 ; j < (sizeof(r_[0].values) / sizeof(r_[0].values[0])) ; j++) {
@@ -83,10 +83,10 @@ simde_vld3_f32(simde_float32 const *ptr) {
   #else
     simde_float32x2_private r_[3];
     #if defined(SIMDE_RISCV_V_NATIVE) && (SIMDE_NATURAL_VECTOR_SIZE >= 128)
-      vfloat32mf2x3_t dest = __riscv_vlseg3e32_v_f32mf2x3(&ptr[0], 2);
-      r_[0].sv64 = __riscv_vget_v_f32mf2x3_f32mf2(dest, 0);
-      r_[1].sv64 = __riscv_vget_v_f32mf2x3_f32mf2(dest, 1);
-      r_[2].sv64 = __riscv_vget_v_f32mf2x3_f32mf2(dest, 2);
+      vfloat32m1x3_t dest = __riscv_vlseg3e32_v_f32m1x3(&ptr[0], 2);
+      r_[0].sv64 = __riscv_vget_v_f32m1x3_f32m1(dest, 0);
+      r_[1].sv64 = __riscv_vget_v_f32m1x3_f32m1(dest, 1);
+      r_[2].sv64 = __riscv_vget_v_f32m1x3_f32m1(dest, 2);
     #else
       for (size_t i = 0; i < (sizeof(r_) / sizeof(r_[0])); i++) {
         for (size_t j = 0 ; j < (sizeof(r_[0].values) / sizeof(r_[0].values[0])) ; j++) {
@@ -149,10 +149,10 @@ simde_vld3_s8(int8_t const *ptr) {
   #else
     simde_int8x8_private r_[3];
     #if defined(SIMDE_RISCV_V_NATIVE) && (SIMDE_NATURAL_VECTOR_SIZE >= 128)
-      vint8mf2x3_t dest = __riscv_vlseg3e8_v_i8mf2x3(&ptr[0], 8);
-      r_[0].sv64 = __riscv_vget_v_i8mf2x3_i8mf2(dest, 0);
-      r_[1].sv64 = __riscv_vget_v_i8mf2x3_i8mf2(dest, 1);
-      r_[2].sv64 = __riscv_vget_v_i8mf2x3_i8mf2(dest, 2);
+      vint8m1x3_t dest = __riscv_vlseg3e8_v_i8m1x3(&ptr[0], 8);
+      r_[0].sv64 = __riscv_vget_v_i8m1x3_i8m1(dest, 0);
+      r_[1].sv64 = __riscv_vget_v_i8m1x3_i8m1(dest, 1);
+      r_[2].sv64 = __riscv_vget_v_i8m1x3_i8m1(dest, 2);
     #else
       for (size_t i = 0; i < (sizeof(r_) / sizeof(r_[0])); i++) {
         for (size_t j = 0 ; j < (sizeof(r_[0].values) / sizeof(r_[0].values[0])) ; j++) {
@@ -182,10 +182,10 @@ simde_vld3_s16(int16_t const *ptr) {
   #else
     simde_int16x4_private r_[3];
     #if defined(SIMDE_RISCV_V_NATIVE) && (SIMDE_NATURAL_VECTOR_SIZE >= 128)
-      vint16mf2x3_t dest = __riscv_vlseg3e16_v_i16mf2x3(&ptr[0], 4);
-      r_[0].sv64 = __riscv_vget_v_i16mf2x3_i16mf2(dest, 0);
-      r_[1].sv64 = __riscv_vget_v_i16mf2x3_i16mf2(dest, 1);
-      r_[2].sv64 = __riscv_vget_v_i16mf2x3_i16mf2(dest, 2);
+      vint16m1x3_t dest = __riscv_vlseg3e16_v_i16m1x3(&ptr[0], 4);
+      r_[0].sv64 = __riscv_vget_v_i16m1x3_i16m1(dest, 0);
+      r_[1].sv64 = __riscv_vget_v_i16m1x3_i16m1(dest, 1);
+      r_[2].sv64 = __riscv_vget_v_i16m1x3_i16m1(dest, 2);
     #else
       for (size_t i = 0; i < (sizeof(r_) / sizeof(r_[0])); i++) {
         for (size_t j = 0 ; j < (sizeof(r_[0].values) / sizeof(r_[0].values[0])) ; j++) {
@@ -215,10 +215,10 @@ simde_vld3_s32(int32_t const *ptr) {
   #else
     simde_int32x2_private r_[3];
     #if defined(SIMDE_RISCV_V_NATIVE) && (SIMDE_NATURAL_VECTOR_SIZE >= 128)
-      vint32mf2x3_t dest = __riscv_vlseg3e32_v_i32mf2x3(&ptr[0], 2);
-      r_[0].sv64 = __riscv_vget_v_i32mf2x3_i32mf2(dest, 0);
-      r_[1].sv64 = __riscv_vget_v_i32mf2x3_i32mf2(dest, 1);
-      r_[2].sv64 = __riscv_vget_v_i32mf2x3_i32mf2(dest, 2);
+      vint32m1x3_t dest = __riscv_vlseg3e32_v_i32m1x3(&ptr[0], 2);
+      r_[0].sv64 = __riscv_vget_v_i32m1x3_i32m1(dest, 0);
+      r_[1].sv64 = __riscv_vget_v_i32m1x3_i32m1(dest, 1);
+      r_[2].sv64 = __riscv_vget_v_i32m1x3_i32m1(dest, 2);
     #else
       for (size_t i = 0; i < (sizeof(r_) / sizeof(r_[0])); i++) {
         for (size_t j = 0 ; j < (sizeof(r_[0].values) / sizeof(r_[0].values[0])) ; j++) {
@@ -281,10 +281,10 @@ simde_vld3_u8(uint8_t const *ptr) {
   #else
     simde_uint8x8_private r_[3];
     #if defined(SIMDE_RISCV_V_NATIVE) && (SIMDE_NATURAL_VECTOR_SIZE >= 128)
-      vuint8mf2x3_t dest = __riscv_vlseg3e8_v_u8mf2x3(&ptr[0], 8);
-      r_[0].sv64 = __riscv_vget_v_u8mf2x3_u8mf2(dest, 0);
-      r_[1].sv64 = __riscv_vget_v_u8mf2x3_u8mf2(dest, 1);
-      r_[2].sv64 = __riscv_vget_v_u8mf2x3_u8mf2(dest, 2);
+      vuint8m1x3_t dest = __riscv_vlseg3e8_v_u8m1x3(&ptr[0], 8);
+      r_[0].sv64 = __riscv_vget_v_u8m1x3_u8m1(dest, 0);
+      r_[1].sv64 = __riscv_vget_v_u8m1x3_u8m1(dest, 1);
+      r_[2].sv64 = __riscv_vget_v_u8m1x3_u8m1(dest, 2);
     #else
       for (size_t i = 0; i < (sizeof(r_) / sizeof(r_[0])); i++) {
         for (size_t j = 0 ; j < (sizeof(r_[0].values) / sizeof(r_[0].values[0])) ; j++) {
@@ -314,10 +314,10 @@ simde_vld3_u16(uint16_t const *ptr) {
   #else
     simde_uint16x4_private r_[3];
     #if defined(SIMDE_RISCV_V_NATIVE) && (SIMDE_NATURAL_VECTOR_SIZE >= 128)
-      vuint16mf2x3_t dest = __riscv_vlseg3e16_v_u16mf2x3(&ptr[0], 4);
-      r_[0].sv64 = __riscv_vget_v_u16mf2x3_u16mf2(dest, 0);
-      r_[1].sv64 = __riscv_vget_v_u16mf2x3_u16mf2(dest, 1);
-      r_[2].sv64 = __riscv_vget_v_u16mf2x3_u16mf2(dest, 2);
+      vuint16m1x3_t dest = __riscv_vlseg3e16_v_u16m1x3(&ptr[0], 4);
+      r_[0].sv64 = __riscv_vget_v_u16m1x3_u16m1(dest, 0);
+      r_[1].sv64 = __riscv_vget_v_u16m1x3_u16m1(dest, 1);
+      r_[2].sv64 = __riscv_vget_v_u16m1x3_u16m1(dest, 2);
     #else
       for (size_t i = 0; i < (sizeof(r_) / sizeof(r_[0])); i++) {
         for (size_t j = 0 ; j < (sizeof(r_[0].values) / sizeof(r_[0].values[0])) ; j++) {
@@ -347,10 +347,10 @@ simde_vld3_u32(uint32_t const *ptr) {
   #else
     simde_uint32x2_private r_[3];
     #if defined(SIMDE_RISCV_V_NATIVE) && (SIMDE_NATURAL_VECTOR_SIZE >= 128)
-      vuint32mf2x3_t dest = __riscv_vlseg3e32_v_u32mf2x3(&ptr[0], 2);
-      r_[0].sv64 = __riscv_vget_v_u32mf2x3_u32mf2(dest, 0);
-      r_[1].sv64 = __riscv_vget_v_u32mf2x3_u32mf2(dest, 1);
-      r_[2].sv64 = __riscv_vget_v_u32mf2x3_u32mf2(dest, 2);
+      vuint32m1x3_t dest = __riscv_vlseg3e32_v_u32m1x3(&ptr[0], 2);
+      r_[0].sv64 = __riscv_vget_v_u32m1x3_u32m1(dest, 0);
+      r_[1].sv64 = __riscv_vget_v_u32m1x3_u32m1(dest, 1);
+      r_[2].sv64 = __riscv_vget_v_u32m1x3_u32m1(dest, 2);
     #else
       for (size_t i = 0; i < (sizeof(r_) / sizeof(r_[0])); i++) {
         for (size_t j = 0 ; j < (sizeof(r_[0].values) / sizeof(r_[0].values[0])) ; j++) {

--- a/simde/arm/neon/ld3.h
+++ b/simde/arm/neon/ld3.h
@@ -82,7 +82,7 @@ simde_vld3_f32(simde_float32 const *ptr) {
     return vld3_f32(ptr);
   #else
     simde_float32x2_private r_[3];
-    #if defined(SIMDE_RISCV_V_NATIVE) && (SIMDE_NATURAL_VECTOR_SIZE >= 128)
+    #if defined(SIMDE_RISCV_V_NATIVE)
       vfloat32m1x3_t dest = __riscv_vlseg3e32_v_f32m1x3(&ptr[0], 2);
       r_[0].sv64 = __riscv_vget_v_f32m1x3_f32m1(dest, 0);
       r_[1].sv64 = __riscv_vget_v_f32m1x3_f32m1(dest, 1);
@@ -115,7 +115,7 @@ simde_vld3_f64(simde_float64 const *ptr) {
     return vld3_f64(ptr);
   #else
     simde_float64x1_private r_[3];
-    #if defined(SIMDE_RISCV_V_NATIVE) && (SIMDE_NATURAL_VECTOR_SIZE >= 128)
+    #if defined(SIMDE_RISCV_V_NATIVE)
       vfloat64m1x3_t dest = __riscv_vlseg3e64_v_f64m1x3(&ptr[0], 1);
       r_[0].sv64 = __riscv_vget_v_f64m1x3_f64m1(dest, 0);
       r_[1].sv64 = __riscv_vget_v_f64m1x3_f64m1(dest, 1);
@@ -148,7 +148,7 @@ simde_vld3_s8(int8_t const *ptr) {
     return vld3_s8(ptr);
   #else
     simde_int8x8_private r_[3];
-    #if defined(SIMDE_RISCV_V_NATIVE) && (SIMDE_NATURAL_VECTOR_SIZE >= 128)
+    #if defined(SIMDE_RISCV_V_NATIVE)
       vint8m1x3_t dest = __riscv_vlseg3e8_v_i8m1x3(&ptr[0], 8);
       r_[0].sv64 = __riscv_vget_v_i8m1x3_i8m1(dest, 0);
       r_[1].sv64 = __riscv_vget_v_i8m1x3_i8m1(dest, 1);
@@ -181,7 +181,7 @@ simde_vld3_s16(int16_t const *ptr) {
     return vld3_s16(ptr);
   #else
     simde_int16x4_private r_[3];
-    #if defined(SIMDE_RISCV_V_NATIVE) && (SIMDE_NATURAL_VECTOR_SIZE >= 128)
+    #if defined(SIMDE_RISCV_V_NATIVE)
       vint16m1x3_t dest = __riscv_vlseg3e16_v_i16m1x3(&ptr[0], 4);
       r_[0].sv64 = __riscv_vget_v_i16m1x3_i16m1(dest, 0);
       r_[1].sv64 = __riscv_vget_v_i16m1x3_i16m1(dest, 1);
@@ -214,7 +214,7 @@ simde_vld3_s32(int32_t const *ptr) {
     return vld3_s32(ptr);
   #else
     simde_int32x2_private r_[3];
-    #if defined(SIMDE_RISCV_V_NATIVE) && (SIMDE_NATURAL_VECTOR_SIZE >= 128)
+    #if defined(SIMDE_RISCV_V_NATIVE)
       vint32m1x3_t dest = __riscv_vlseg3e32_v_i32m1x3(&ptr[0], 2);
       r_[0].sv64 = __riscv_vget_v_i32m1x3_i32m1(dest, 0);
       r_[1].sv64 = __riscv_vget_v_i32m1x3_i32m1(dest, 1);
@@ -247,7 +247,7 @@ simde_vld3_s64(int64_t const *ptr) {
     return vld3_s64(ptr);
   #else
     simde_int64x1_private r_[3];
-    #if defined(SIMDE_RISCV_V_NATIVE) && (SIMDE_NATURAL_VECTOR_SIZE >= 128)
+    #if defined(SIMDE_RISCV_V_NATIVE)
       vint64m1x3_t dest = __riscv_vlseg3e64_v_i64m1x3(&ptr[0], 1);
       r_[0].sv64 = __riscv_vget_v_i64m1x3_i64m1(dest, 0);
       r_[1].sv64 = __riscv_vget_v_i64m1x3_i64m1(dest, 1);
@@ -280,7 +280,7 @@ simde_vld3_u8(uint8_t const *ptr) {
     return vld3_u8(ptr);
   #else
     simde_uint8x8_private r_[3];
-    #if defined(SIMDE_RISCV_V_NATIVE) && (SIMDE_NATURAL_VECTOR_SIZE >= 128)
+    #if defined(SIMDE_RISCV_V_NATIVE)
       vuint8m1x3_t dest = __riscv_vlseg3e8_v_u8m1x3(&ptr[0], 8);
       r_[0].sv64 = __riscv_vget_v_u8m1x3_u8m1(dest, 0);
       r_[1].sv64 = __riscv_vget_v_u8m1x3_u8m1(dest, 1);
@@ -313,7 +313,7 @@ simde_vld3_u16(uint16_t const *ptr) {
     return vld3_u16(ptr);
   #else
     simde_uint16x4_private r_[3];
-    #if defined(SIMDE_RISCV_V_NATIVE) && (SIMDE_NATURAL_VECTOR_SIZE >= 128)
+    #if defined(SIMDE_RISCV_V_NATIVE)
       vuint16m1x3_t dest = __riscv_vlseg3e16_v_u16m1x3(&ptr[0], 4);
       r_[0].sv64 = __riscv_vget_v_u16m1x3_u16m1(dest, 0);
       r_[1].sv64 = __riscv_vget_v_u16m1x3_u16m1(dest, 1);
@@ -346,7 +346,7 @@ simde_vld3_u32(uint32_t const *ptr) {
     return vld3_u32(ptr);
   #else
     simde_uint32x2_private r_[3];
-    #if defined(SIMDE_RISCV_V_NATIVE) && (SIMDE_NATURAL_VECTOR_SIZE >= 128)
+    #if defined(SIMDE_RISCV_V_NATIVE)
       vuint32m1x3_t dest = __riscv_vlseg3e32_v_u32m1x3(&ptr[0], 2);
       r_[0].sv64 = __riscv_vget_v_u32m1x3_u32m1(dest, 0);
       r_[1].sv64 = __riscv_vget_v_u32m1x3_u32m1(dest, 1);
@@ -379,7 +379,7 @@ simde_vld3_u64(uint64_t const *ptr) {
     return vld3_u64(ptr);
   #else
     simde_uint64x1_private r_[3];
-    #if defined(SIMDE_RISCV_V_NATIVE) && (SIMDE_NATURAL_VECTOR_SIZE >= 128)
+    #if defined(SIMDE_RISCV_V_NATIVE)
       vuint64m1x3_t dest = __riscv_vlseg3e64_v_u64m1x3(&ptr[0], 1);
       r_[0].sv64 = __riscv_vget_v_u64m1x3_u64m1(dest, 0);
       r_[1].sv64 = __riscv_vget_v_u64m1x3_u64m1(dest, 1);
@@ -443,7 +443,7 @@ simde_float32x4x3_t
 simde_vld3q_f32(simde_float32 const *ptr) {
   #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
     return vld3q_f32(ptr);
-  #elif defined(SIMDE_RISCV_V_NATIVE) && (SIMDE_NATURAL_VECTOR_SIZE >= 128)
+  #elif defined(SIMDE_RISCV_V_NATIVE)
     simde_float32x4_private r_[3];
     vfloat32m1x3_t dest = __riscv_vlseg3e32_v_f32m1x3(&ptr[0], 4);
     r_[0].sv128 = __riscv_vget_v_f32m1x3_f32m1(dest, 0);
@@ -483,7 +483,7 @@ simde_float64x2x3_t
 simde_vld3q_f64(simde_float64 const *ptr) {
   #if defined(SIMDE_ARM_NEON_A64V8_NATIVE)
     return vld3q_f64(ptr);
-  #elif defined(SIMDE_RISCV_V_NATIVE) && (SIMDE_NATURAL_VECTOR_SIZE >= 128)
+  #elif defined(SIMDE_RISCV_V_NATIVE)
     simde_float64x2_private r_[3];
     vfloat64m1x3_t dest = __riscv_vlseg3e64_v_f64m1x3(&ptr[0], 2);
     r_[0].sv128 = __riscv_vget_v_f64m1x3_f64m1(dest, 0);
@@ -523,7 +523,7 @@ simde_int8x16x3_t
 simde_vld3q_s8(int8_t const *ptr) {
   #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
     return vld3q_s8(ptr);
-  #elif defined(SIMDE_RISCV_V_NATIVE) && (SIMDE_NATURAL_VECTOR_SIZE >= 128)
+  #elif defined(SIMDE_RISCV_V_NATIVE)
     simde_int8x16_private r_[3];
     vint8m1x3_t dest = __riscv_vlseg3e8_v_i8m1x3(&ptr[0], 16);
     r_[0].sv128 = __riscv_vget_v_i8m1x3_i8m1(dest, 0);
@@ -563,7 +563,7 @@ simde_int16x8x3_t
 simde_vld3q_s16(int16_t const *ptr) {
   #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
     return vld3q_s16(ptr);
-  #elif defined(SIMDE_RISCV_V_NATIVE) && (SIMDE_NATURAL_VECTOR_SIZE >= 128)
+  #elif defined(SIMDE_RISCV_V_NATIVE)
     simde_int16x8_private r_[3];
     vint16m1x3_t dest = __riscv_vlseg3e16_v_i16m1x3(&ptr[0], 8);
     r_[0].sv128 = __riscv_vget_v_i16m1x3_i16m1(dest, 0);
@@ -603,7 +603,7 @@ simde_int32x4x3_t
 simde_vld3q_s32(int32_t const *ptr) {
   #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
     return vld3q_s32(ptr);
-  #elif defined(SIMDE_RISCV_V_NATIVE) && (SIMDE_NATURAL_VECTOR_SIZE >= 128)
+  #elif defined(SIMDE_RISCV_V_NATIVE)
     simde_int32x4_private r_[3];
     vint32m1x3_t dest = __riscv_vlseg3e32_v_i32m1x3(&ptr[0], 4);
     r_[0].sv128 = __riscv_vget_v_i32m1x3_i32m1(dest, 0);
@@ -643,7 +643,7 @@ simde_int64x2x3_t
 simde_vld3q_s64(int64_t const *ptr) {
   #if defined(SIMDE_ARM_NEON_A64V8_NATIVE)
     return vld3q_s64(ptr);
-  #elif defined(SIMDE_RISCV_V_NATIVE) && (SIMDE_NATURAL_VECTOR_SIZE >= 128)
+  #elif defined(SIMDE_RISCV_V_NATIVE)
     simde_int64x2_private r_[3];
     vint64m1x3_t dest = __riscv_vlseg3e64_v_i64m1x3(&ptr[0], 2);
     r_[0].sv128 = __riscv_vget_v_i64m1x3_i64m1(dest, 0);
@@ -684,7 +684,7 @@ simde_uint8x16x3_t
 simde_vld3q_u8(uint8_t const *ptr) {
   #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
     return vld3q_u8(ptr);
-  #elif defined(SIMDE_RISCV_V_NATIVE) && (SIMDE_NATURAL_VECTOR_SIZE >= 128)
+  #elif defined(SIMDE_RISCV_V_NATIVE)
     simde_uint8x16_private r_[3];
     vuint8m1x3_t dest = __riscv_vlseg3e8_v_u8m1x3(&ptr[0], 16);
     r_[0].sv128 = __riscv_vget_v_u8m1x3_u8m1(dest, 0);
@@ -724,7 +724,7 @@ simde_uint16x8x3_t
 simde_vld3q_u16(uint16_t const *ptr) {
   #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
     return vld3q_u16(ptr);
-  #elif defined(SIMDE_RISCV_V_NATIVE) && (SIMDE_NATURAL_VECTOR_SIZE >= 128)
+  #elif defined(SIMDE_RISCV_V_NATIVE)
     simde_uint16x8_private r_[3];
     vuint16m1x3_t dest = __riscv_vlseg3e16_v_u16m1x3(&ptr[0], 8);
     r_[0].sv128 = __riscv_vget_v_u16m1x3_u16m1(dest, 0);
@@ -764,7 +764,7 @@ simde_uint32x4x3_t
 simde_vld3q_u32(uint32_t const *ptr) {
   #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
     return vld3q_u32(ptr);
-  #elif defined(SIMDE_RISCV_V_NATIVE) && (SIMDE_NATURAL_VECTOR_SIZE >= 128)
+  #elif defined(SIMDE_RISCV_V_NATIVE)
     simde_uint32x4_private r_[3];
     vuint32m1x3_t dest = __riscv_vlseg3e32_v_u32m1x3(&ptr[0], 4);
     r_[0].sv128 = __riscv_vget_v_u32m1x3_u32m1(dest, 0);
@@ -804,7 +804,7 @@ simde_uint64x2x3_t
 simde_vld3q_u64(uint64_t const *ptr) {
   #if defined(SIMDE_ARM_NEON_A64V8_NATIVE)
     return vld3q_u64(ptr);
-  #elif defined(SIMDE_RISCV_V_NATIVE) && (SIMDE_NATURAL_VECTOR_SIZE >= 128)
+  #elif defined(SIMDE_RISCV_V_NATIVE)
     simde_uint64x2_private r_[3];
     vuint64m1x3_t dest = __riscv_vlseg3e64_v_u64m1x3(&ptr[0], 2);
     r_[0].sv128 = __riscv_vget_v_u64m1x3_u64m1(dest, 0);

--- a/simde/arm/neon/ld3.h
+++ b/simde/arm/neon/ld3.h
@@ -116,10 +116,10 @@ simde_vld3_f64(simde_float64 const *ptr) {
   #else
     simde_float64x1_private r_[3];
     #if defined(SIMDE_RISCV_V_NATIVE) && (SIMDE_NATURAL_VECTOR_SIZE >= 128)
-      vfloat64mf2x3_t dest = __riscv_vlseg3e64_v_f64mf2x3(&ptr[0], 1);
-      r_[0].sv64 = __riscv_vget_v_f64mf2x3_f64mf2(dest, 0);
-      r_[1].sv64 = __riscv_vget_v_f64mf2x3_f64mf2(dest, 1);
-      r_[2].sv64 = __riscv_vget_v_f64mf2x3_f64mf2(dest, 2);
+      vfloat64m1x3_t dest = __riscv_vlseg3e64_v_f64m1x3(&ptr[0], 1);
+      r_[0].sv64 = __riscv_vget_v_f64m1x3_f64m1(dest, 0);
+      r_[1].sv64 = __riscv_vget_v_f64m1x3_f64m1(dest, 1);
+      r_[2].sv64 = __riscv_vget_v_f64m1x3_f64m1(dest, 2);
     #else
       for (size_t i = 0; i < (sizeof(r_) / sizeof(r_[0])); i++) {
         for (size_t j = 0 ; j < (sizeof(r_[0].values) / sizeof(r_[0].values[0])) ; j++) {
@@ -248,10 +248,10 @@ simde_vld3_s64(int64_t const *ptr) {
   #else
     simde_int64x1_private r_[3];
     #if defined(SIMDE_RISCV_V_NATIVE) && (SIMDE_NATURAL_VECTOR_SIZE >= 128)
-      vint64mf2x3_t dest = __riscv_vlseg3e64_v_i64mf2x3(&ptr[0], 1);
-      r_[0].sv64 = __riscv_vget_v_i64mf2x3_i64mf2(dest, 0);
-      r_[1].sv64 = __riscv_vget_v_i64mf2x3_i64mf2(dest, 1);
-      r_[2].sv64 = __riscv_vget_v_i64mf2x3_i64mf2(dest, 2);
+      vint64m1x3_t dest = __riscv_vlseg3e64_v_i64m1x3(&ptr[0], 1);
+      r_[0].sv64 = __riscv_vget_v_i64m1x3_i64m1(dest, 0);
+      r_[1].sv64 = __riscv_vget_v_i64m1x3_i64m1(dest, 1);
+      r_[2].sv64 = __riscv_vget_v_i64m1x3_i64m1(dest, 2);
     #else
       for (size_t i = 0; i < (sizeof(r_) / sizeof(r_[0])); i++) {
         for (size_t j = 0 ; j < (sizeof(r_[0].values) / sizeof(r_[0].values[0])) ; j++) {
@@ -380,10 +380,10 @@ simde_vld3_u64(uint64_t const *ptr) {
   #else
     simde_uint64x1_private r_[3];
     #if defined(SIMDE_RISCV_V_NATIVE) && (SIMDE_NATURAL_VECTOR_SIZE >= 128)
-      vuint64mf2x3_t dest = __riscv_vlseg3e64_v_u64mf2x3(&ptr[0], 1);
-      r_[0].sv64 = __riscv_vget_v_u64mf2x3_u64mf2(dest, 0);
-      r_[1].sv64 = __riscv_vget_v_u64mf2x3_u64mf2(dest, 1);
-      r_[2].sv64 = __riscv_vget_v_u64mf2x3_u64mf2(dest, 2);
+      vuint64m1x3_t dest = __riscv_vlseg3e64_v_u64m1x3(&ptr[0], 1);
+      r_[0].sv64 = __riscv_vget_v_u64m1x3_u64m1(dest, 0);
+      r_[1].sv64 = __riscv_vget_v_u64m1x3_u64m1(dest, 1);
+      r_[2].sv64 = __riscv_vget_v_u64m1x3_u64m1(dest, 2);
     #else
       for (size_t i = 0; i < (sizeof(r_) / sizeof(r_[0])); i++) {
         for (size_t j = 0 ; j < (sizeof(r_[0].values) / sizeof(r_[0].values[0])) ; j++) {

--- a/simde/arm/neon/ld3.h
+++ b/simde/arm/neon/ld3.h
@@ -24,6 +24,7 @@
  *   2020      Evan Nemerson <evan@nemerson.com>
  *   2020      Sean Maher <seanptmaher@gmail.com>
  *   2023      Yi-Yen Chung <eric681@andestech.com> (Copyright owned by Andes Technology)
+ *   2023      Chi-Wei Chu <wewe5215@gapp.nthu.edu.tw>
  */
 
 #if !defined(SIMDE_ARM_NEON_LD3_H)
@@ -48,13 +49,18 @@ simde_vld3_f16(simde_float16 const *ptr) {
     return vld3_f16(ptr);
   #else
     simde_float16x4_private r_[3];
-
-    for (size_t i = 0; i < (sizeof(r_) / sizeof(r_[0])); i++) {
-      for (size_t j = 0 ; j < (sizeof(r_[0].values) / sizeof(r_[0].values[0])) ; j++) {
-        r_[i].values[j] = ptr[i + (j * (sizeof(r_) / sizeof(r_[0])))];
+    #if defined(SIMDE_RISCV_V_NATIVE) && SIMDE_ARCH_RISCV_ZVFH && (SIMDE_NATURAL_VECTOR_SIZE >= 128)
+      vfloat16mf2x3_t dest = __riscv_vlseg3e16_v_f16mf2x3((_Float16 *)&ptr[0], 4);
+      r_[0].sv64 = __riscv_vget_v_f16mf2x3_f16mf2(dest, 0);
+      r_[1].sv64 = __riscv_vget_v_f16mf2x3_f16mf2(dest, 1);
+      r_[2].sv64 = __riscv_vget_v_f16mf2x3_f16mf2(dest, 2);
+    #else
+      for (size_t i = 0; i < (sizeof(r_) / sizeof(r_[0])); i++) {
+        for (size_t j = 0 ; j < (sizeof(r_[0].values) / sizeof(r_[0].values[0])) ; j++) {
+          r_[i].values[j] = ptr[i + (j * (sizeof(r_) / sizeof(r_[0])))];
+        }
       }
-    }
-
+    #endif
     simde_float16x4x3_t r = { {
       simde_float16x4_from_private(r_[0]),
       simde_float16x4_from_private(r_[1]),
@@ -76,13 +82,18 @@ simde_vld3_f32(simde_float32 const *ptr) {
     return vld3_f32(ptr);
   #else
     simde_float32x2_private r_[3];
-
-    for (size_t i = 0; i < (sizeof(r_) / sizeof(r_[0])); i++) {
-      for (size_t j = 0 ; j < (sizeof(r_[0].values) / sizeof(r_[0].values[0])) ; j++) {
-        r_[i].values[j] = ptr[i + (j * (sizeof(r_) / sizeof(r_[0])))];
+    #if defined(SIMDE_RISCV_V_NATIVE) && (SIMDE_NATURAL_VECTOR_SIZE >= 128)
+      vfloat32mf2x3_t dest = __riscv_vlseg3e32_v_f32mf2x3(&ptr[0], 2);
+      r_[0].sv64 = __riscv_vget_v_f32mf2x3_f32mf2(dest, 0);
+      r_[1].sv64 = __riscv_vget_v_f32mf2x3_f32mf2(dest, 1);
+      r_[2].sv64 = __riscv_vget_v_f32mf2x3_f32mf2(dest, 2);
+    #else
+      for (size_t i = 0; i < (sizeof(r_) / sizeof(r_[0])); i++) {
+        for (size_t j = 0 ; j < (sizeof(r_[0].values) / sizeof(r_[0].values[0])) ; j++) {
+          r_[i].values[j] = ptr[i + (j * (sizeof(r_) / sizeof(r_[0])))];
+        }
       }
-    }
-
+    #endif
     simde_float32x2x3_t r = { {
       simde_float32x2_from_private(r_[0]),
       simde_float32x2_from_private(r_[1]),
@@ -104,13 +115,18 @@ simde_vld3_f64(simde_float64 const *ptr) {
     return vld3_f64(ptr);
   #else
     simde_float64x1_private r_[3];
-
-    for (size_t i = 0; i < (sizeof(r_) / sizeof(r_[0])); i++) {
-      for (size_t j = 0 ; j < (sizeof(r_[0].values) / sizeof(r_[0].values[0])) ; j++) {
-        r_[i].values[j] = ptr[i + (j * (sizeof(r_) / sizeof(r_[0])))];
+    #if defined(SIMDE_RISCV_V_NATIVE) && (SIMDE_NATURAL_VECTOR_SIZE >= 128)
+      vfloat64mf2x3_t dest = __riscv_vlseg3e64_v_f64mf2x3(&ptr[0], 1);
+      r_[0].sv64 = __riscv_vget_v_f64mf2x3_f64mf2(dest, 0);
+      r_[1].sv64 = __riscv_vget_v_f64mf2x3_f64mf2(dest, 1);
+      r_[2].sv64 = __riscv_vget_v_f64mf2x3_f64mf2(dest, 2);
+    #else
+      for (size_t i = 0; i < (sizeof(r_) / sizeof(r_[0])); i++) {
+        for (size_t j = 0 ; j < (sizeof(r_[0].values) / sizeof(r_[0].values[0])) ; j++) {
+          r_[i].values[j] = ptr[i + (j * (sizeof(r_) / sizeof(r_[0])))];
+        }
       }
-    }
-
+    #endif
     simde_float64x1x3_t r = { {
       simde_float64x1_from_private(r_[0]),
       simde_float64x1_from_private(r_[1]),
@@ -132,13 +148,18 @@ simde_vld3_s8(int8_t const *ptr) {
     return vld3_s8(ptr);
   #else
     simde_int8x8_private r_[3];
-
-    for (size_t i = 0; i < (sizeof(r_) / sizeof(r_[0])); i++) {
-      for (size_t j = 0 ; j < (sizeof(r_[0].values) / sizeof(r_[0].values[0])) ; j++) {
-        r_[i].values[j] = ptr[i + (j * (sizeof(r_) / sizeof(r_[0])))];
+    #if defined(SIMDE_RISCV_V_NATIVE) && (SIMDE_NATURAL_VECTOR_SIZE >= 128)
+      vint8mf2x3_t dest = __riscv_vlseg3e8_v_i8mf2x3(&ptr[0], 8);
+      r_[0].sv64 = __riscv_vget_v_i8mf2x3_i8mf2(dest, 0);
+      r_[1].sv64 = __riscv_vget_v_i8mf2x3_i8mf2(dest, 1);
+      r_[2].sv64 = __riscv_vget_v_i8mf2x3_i8mf2(dest, 2);
+    #else
+      for (size_t i = 0; i < (sizeof(r_) / sizeof(r_[0])); i++) {
+        for (size_t j = 0 ; j < (sizeof(r_[0].values) / sizeof(r_[0].values[0])) ; j++) {
+          r_[i].values[j] = ptr[i + (j * (sizeof(r_) / sizeof(r_[0])))];
+        }
       }
-    }
-
+    #endif
     simde_int8x8x3_t r = { {
       simde_int8x8_from_private(r_[0]),
       simde_int8x8_from_private(r_[1]),
@@ -160,13 +181,18 @@ simde_vld3_s16(int16_t const *ptr) {
     return vld3_s16(ptr);
   #else
     simde_int16x4_private r_[3];
-
-    for (size_t i = 0; i < (sizeof(r_) / sizeof(r_[0])); i++) {
-      for (size_t j = 0 ; j < (sizeof(r_[0].values) / sizeof(r_[0].values[0])) ; j++) {
-        r_[i].values[j] = ptr[i + (j * (sizeof(r_) / sizeof(r_[0])))];
+    #if defined(SIMDE_RISCV_V_NATIVE) && (SIMDE_NATURAL_VECTOR_SIZE >= 128)
+      vint16mf2x3_t dest = __riscv_vlseg3e16_v_i16mf2x3(&ptr[0], 4);
+      r_[0].sv64 = __riscv_vget_v_i16mf2x3_i16mf2(dest, 0);
+      r_[1].sv64 = __riscv_vget_v_i16mf2x3_i16mf2(dest, 1);
+      r_[2].sv64 = __riscv_vget_v_i16mf2x3_i16mf2(dest, 2);
+    #else
+      for (size_t i = 0; i < (sizeof(r_) / sizeof(r_[0])); i++) {
+        for (size_t j = 0 ; j < (sizeof(r_[0].values) / sizeof(r_[0].values[0])) ; j++) {
+          r_[i].values[j] = ptr[i + (j * (sizeof(r_) / sizeof(r_[0])))];
+        }
       }
-    }
-
+    #endif
     simde_int16x4x3_t r = { {
       simde_int16x4_from_private(r_[0]),
       simde_int16x4_from_private(r_[1]),
@@ -188,13 +214,18 @@ simde_vld3_s32(int32_t const *ptr) {
     return vld3_s32(ptr);
   #else
     simde_int32x2_private r_[3];
-
-    for (size_t i = 0; i < (sizeof(r_) / sizeof(r_[0])); i++) {
-      for (size_t j = 0 ; j < (sizeof(r_[0].values) / sizeof(r_[0].values[0])) ; j++) {
-        r_[i].values[j] = ptr[i + (j * (sizeof(r_) / sizeof(r_[0])))];
+    #if defined(SIMDE_RISCV_V_NATIVE) && (SIMDE_NATURAL_VECTOR_SIZE >= 128)
+      vint32mf2x3_t dest = __riscv_vlseg3e32_v_i32mf2x3(&ptr[0], 2);
+      r_[0].sv64 = __riscv_vget_v_i32mf2x3_i32mf2(dest, 0);
+      r_[1].sv64 = __riscv_vget_v_i32mf2x3_i32mf2(dest, 1);
+      r_[2].sv64 = __riscv_vget_v_i32mf2x3_i32mf2(dest, 2);
+    #else
+      for (size_t i = 0; i < (sizeof(r_) / sizeof(r_[0])); i++) {
+        for (size_t j = 0 ; j < (sizeof(r_[0].values) / sizeof(r_[0].values[0])) ; j++) {
+          r_[i].values[j] = ptr[i + (j * (sizeof(r_) / sizeof(r_[0])))];
+        }
       }
-    }
-
+    #endif
     simde_int32x2x3_t r = { {
       simde_int32x2_from_private(r_[0]),
       simde_int32x2_from_private(r_[1]),
@@ -216,13 +247,18 @@ simde_vld3_s64(int64_t const *ptr) {
     return vld3_s64(ptr);
   #else
     simde_int64x1_private r_[3];
-
-    for (size_t i = 0; i < (sizeof(r_) / sizeof(r_[0])); i++) {
-      for (size_t j = 0 ; j < (sizeof(r_[0].values) / sizeof(r_[0].values[0])) ; j++) {
-        r_[i].values[j] = ptr[i + (j * (sizeof(r_) / sizeof(r_[0])))];
+    #if defined(SIMDE_RISCV_V_NATIVE) && (SIMDE_NATURAL_VECTOR_SIZE >= 128)
+      vint64mf2x3_t dest = __riscv_vlseg3e64_v_i64mf2x3(&ptr[0], 1);
+      r_[0].sv64 = __riscv_vget_v_i64mf2x3_i64mf2(dest, 0);
+      r_[1].sv64 = __riscv_vget_v_i64mf2x3_i64mf2(dest, 1);
+      r_[2].sv64 = __riscv_vget_v_i64mf2x3_i64mf2(dest, 2);
+    #else
+      for (size_t i = 0; i < (sizeof(r_) / sizeof(r_[0])); i++) {
+        for (size_t j = 0 ; j < (sizeof(r_[0].values) / sizeof(r_[0].values[0])) ; j++) {
+          r_[i].values[j] = ptr[i + (j * (sizeof(r_) / sizeof(r_[0])))];
+        }
       }
-    }
-
+    #endif
     simde_int64x1x3_t r = { {
       simde_int64x1_from_private(r_[0]),
       simde_int64x1_from_private(r_[1]),
@@ -244,13 +280,18 @@ simde_vld3_u8(uint8_t const *ptr) {
     return vld3_u8(ptr);
   #else
     simde_uint8x8_private r_[3];
-
-    for (size_t i = 0; i < (sizeof(r_) / sizeof(r_[0])); i++) {
-      for (size_t j = 0 ; j < (sizeof(r_[0].values) / sizeof(r_[0].values[0])) ; j++) {
-        r_[i].values[j] = ptr[i + (j * (sizeof(r_) / sizeof(r_[0])))];
+    #if defined(SIMDE_RISCV_V_NATIVE) && (SIMDE_NATURAL_VECTOR_SIZE >= 128)
+      vuint8mf2x3_t dest = __riscv_vlseg3e8_v_u8mf2x3(&ptr[0], 8);
+      r_[0].sv64 = __riscv_vget_v_u8mf2x3_u8mf2(dest, 0);
+      r_[1].sv64 = __riscv_vget_v_u8mf2x3_u8mf2(dest, 1);
+      r_[2].sv64 = __riscv_vget_v_u8mf2x3_u8mf2(dest, 2);
+    #else
+      for (size_t i = 0; i < (sizeof(r_) / sizeof(r_[0])); i++) {
+        for (size_t j = 0 ; j < (sizeof(r_[0].values) / sizeof(r_[0].values[0])) ; j++) {
+          r_[i].values[j] = ptr[i + (j * (sizeof(r_) / sizeof(r_[0])))];
+        }
       }
-    }
-
+    #endif
     simde_uint8x8x3_t r = { {
       simde_uint8x8_from_private(r_[0]),
       simde_uint8x8_from_private(r_[1]),
@@ -272,13 +313,18 @@ simde_vld3_u16(uint16_t const *ptr) {
     return vld3_u16(ptr);
   #else
     simde_uint16x4_private r_[3];
-
-    for (size_t i = 0; i < (sizeof(r_) / sizeof(r_[0])); i++) {
-      for (size_t j = 0 ; j < (sizeof(r_[0].values) / sizeof(r_[0].values[0])) ; j++) {
-        r_[i].values[j] = ptr[i + (j * (sizeof(r_) / sizeof(r_[0])))];
+    #if defined(SIMDE_RISCV_V_NATIVE) && (SIMDE_NATURAL_VECTOR_SIZE >= 128)
+      vuint16mf2x3_t dest = __riscv_vlseg3e16_v_u16mf2x3(&ptr[0], 4);
+      r_[0].sv64 = __riscv_vget_v_u16mf2x3_u16mf2(dest, 0);
+      r_[1].sv64 = __riscv_vget_v_u16mf2x3_u16mf2(dest, 1);
+      r_[2].sv64 = __riscv_vget_v_u16mf2x3_u16mf2(dest, 2);
+    #else
+      for (size_t i = 0; i < (sizeof(r_) / sizeof(r_[0])); i++) {
+        for (size_t j = 0 ; j < (sizeof(r_[0].values) / sizeof(r_[0].values[0])) ; j++) {
+          r_[i].values[j] = ptr[i + (j * (sizeof(r_) / sizeof(r_[0])))];
+        }
       }
-    }
-
+    #endif
     simde_uint16x4x3_t r = { {
       simde_uint16x4_from_private(r_[0]),
       simde_uint16x4_from_private(r_[1]),
@@ -300,13 +346,18 @@ simde_vld3_u32(uint32_t const *ptr) {
     return vld3_u32(ptr);
   #else
     simde_uint32x2_private r_[3];
-
-    for (size_t i = 0; i < (sizeof(r_) / sizeof(r_[0])); i++) {
-      for (size_t j = 0 ; j < (sizeof(r_[0].values) / sizeof(r_[0].values[0])) ; j++) {
-        r_[i].values[j] = ptr[i + (j * (sizeof(r_) / sizeof(r_[0])))];
+    #if defined(SIMDE_RISCV_V_NATIVE) && (SIMDE_NATURAL_VECTOR_SIZE >= 128)
+      vuint32mf2x3_t dest = __riscv_vlseg3e32_v_u32mf2x3(&ptr[0], 2);
+      r_[0].sv64 = __riscv_vget_v_u32mf2x3_u32mf2(dest, 0);
+      r_[1].sv64 = __riscv_vget_v_u32mf2x3_u32mf2(dest, 1);
+      r_[2].sv64 = __riscv_vget_v_u32mf2x3_u32mf2(dest, 2);
+    #else
+      for (size_t i = 0; i < (sizeof(r_) / sizeof(r_[0])); i++) {
+        for (size_t j = 0 ; j < (sizeof(r_[0].values) / sizeof(r_[0].values[0])) ; j++) {
+          r_[i].values[j] = ptr[i + (j * (sizeof(r_) / sizeof(r_[0])))];
+        }
       }
-    }
-
+    #endif
     simde_uint32x2x3_t r = { {
       simde_uint32x2_from_private(r_[0]),
       simde_uint32x2_from_private(r_[1]),
@@ -328,13 +379,18 @@ simde_vld3_u64(uint64_t const *ptr) {
     return vld3_u64(ptr);
   #else
     simde_uint64x1_private r_[3];
-
-    for (size_t i = 0; i < (sizeof(r_) / sizeof(r_[0])); i++) {
-      for (size_t j = 0 ; j < (sizeof(r_[0].values) / sizeof(r_[0].values[0])) ; j++) {
-        r_[i].values[j] = ptr[i + (j * (sizeof(r_) / sizeof(r_[0])))];
+    #if defined(SIMDE_RISCV_V_NATIVE) && (SIMDE_NATURAL_VECTOR_SIZE >= 128)
+      vuint64mf2x3_t dest = __riscv_vlseg3e64_v_u64mf2x3(&ptr[0], 1);
+      r_[0].sv64 = __riscv_vget_v_u64mf2x3_u64mf2(dest, 0);
+      r_[1].sv64 = __riscv_vget_v_u64mf2x3_u64mf2(dest, 1);
+      r_[2].sv64 = __riscv_vget_v_u64mf2x3_u64mf2(dest, 2);
+    #else
+      for (size_t i = 0; i < (sizeof(r_) / sizeof(r_[0])); i++) {
+        for (size_t j = 0 ; j < (sizeof(r_[0].values) / sizeof(r_[0].values[0])) ; j++) {
+          r_[i].values[j] = ptr[i + (j * (sizeof(r_) / sizeof(r_[0])))];
+        }
       }
-    }
-
+    #endif
     simde_uint64x1x3_t r = { {
       simde_uint64x1_from_private(r_[0]),
       simde_uint64x1_from_private(r_[1]),
@@ -356,13 +412,18 @@ simde_vld3q_f16(simde_float16 const *ptr) {
     return vld3q_f16(ptr);
   #else
     simde_float16x8_private r_[3];
-
-    for (size_t i = 0; i < (sizeof(r_) / sizeof(r_[0])); i++) {
-      for (size_t j = 0 ; j < (sizeof(r_[0].values) / sizeof(r_[0].values[0])) ; j++) {
-        r_[i].values[j] = ptr[i + (j * (sizeof(r_) / sizeof(r_[0])))];
+    #if defined(SIMDE_RISCV_V_NATIVE) && SIMDE_ARCH_RISCV_ZVFH && (SIMDE_NATURAL_VECTOR_SIZE >= 128)
+      vfloat16m1x3_t dest = __riscv_vlseg3e16_v_f16m1x3((_Float16 *)&ptr[0], 8);
+      r_[0].sv128 = __riscv_vget_v_f16m1x3_f16m1(dest, 0);
+      r_[1].sv128 = __riscv_vget_v_f16m1x3_f16m1(dest, 1);
+      r_[2].sv128 = __riscv_vget_v_f16m1x3_f16m1(dest, 2);
+    #else
+      for (size_t i = 0; i < (sizeof(r_) / sizeof(r_[0])); i++) {
+        for (size_t j = 0 ; j < (sizeof(r_[0].values) / sizeof(r_[0].values[0])) ; j++) {
+          r_[i].values[j] = ptr[i + (j * (sizeof(r_) / sizeof(r_[0])))];
+        }
       }
-    }
-
+    #endif
     simde_float16x8x3_t r = { {
       simde_float16x8_from_private(r_[0]),
       simde_float16x8_from_private(r_[1]),
@@ -382,6 +443,18 @@ simde_float32x4x3_t
 simde_vld3q_f32(simde_float32 const *ptr) {
   #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
     return vld3q_f32(ptr);
+  #elif defined(SIMDE_RISCV_V_NATIVE) && (SIMDE_NATURAL_VECTOR_SIZE >= 128)
+    simde_float32x4_private r_[3];
+    vfloat32m1x3_t dest = __riscv_vlseg3e32_v_f32m1x3(&ptr[0], 4);
+    r_[0].sv128 = __riscv_vget_v_f32m1x3_f32m1(dest, 0);
+    r_[1].sv128 = __riscv_vget_v_f32m1x3_f32m1(dest, 1);
+    r_[2].sv128 = __riscv_vget_v_f32m1x3_f32m1(dest, 2);
+    simde_float32x4x3_t r = { {
+      simde_float32x4_from_private(r_[0]),
+      simde_float32x4_from_private(r_[1]),
+      simde_float32x4_from_private(r_[2])
+    } };
+    return r;
   #else
     simde_float32x4_private r_[3];
 
@@ -410,6 +483,18 @@ simde_float64x2x3_t
 simde_vld3q_f64(simde_float64 const *ptr) {
   #if defined(SIMDE_ARM_NEON_A64V8_NATIVE)
     return vld3q_f64(ptr);
+  #elif defined(SIMDE_RISCV_V_NATIVE) && (SIMDE_NATURAL_VECTOR_SIZE >= 128)
+    simde_float64x2_private r_[3];
+    vfloat64m1x3_t dest = __riscv_vlseg3e64_v_f64m1x3(&ptr[0], 2);
+    r_[0].sv128 = __riscv_vget_v_f64m1x3_f64m1(dest, 0);
+    r_[1].sv128 = __riscv_vget_v_f64m1x3_f64m1(dest, 1);
+    r_[2].sv128 = __riscv_vget_v_f64m1x3_f64m1(dest, 2);
+    simde_float64x2x3_t r = { {
+      simde_float64x2_from_private(r_[0]),
+      simde_float64x2_from_private(r_[1]),
+      simde_float64x2_from_private(r_[2])
+    } };
+    return r;
   #else
     simde_float64x2_private r_[3];
 
@@ -438,6 +523,18 @@ simde_int8x16x3_t
 simde_vld3q_s8(int8_t const *ptr) {
   #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
     return vld3q_s8(ptr);
+  #elif defined(SIMDE_RISCV_V_NATIVE) && (SIMDE_NATURAL_VECTOR_SIZE >= 128)
+    simde_int8x16_private r_[3];
+    vint8m1x3_t dest = __riscv_vlseg3e8_v_i8m1x3(&ptr[0], 16);
+    r_[0].sv128 = __riscv_vget_v_i8m1x3_i8m1(dest, 0);
+    r_[1].sv128 = __riscv_vget_v_i8m1x3_i8m1(dest, 1);
+    r_[2].sv128 = __riscv_vget_v_i8m1x3_i8m1(dest, 2);
+    simde_int8x16x3_t r = { {
+      simde_int8x16_from_private(r_[0]),
+      simde_int8x16_from_private(r_[1]),
+      simde_int8x16_from_private(r_[2])
+    } };
+    return r;
   #else
     simde_int8x16_private r_[3];
 
@@ -466,6 +563,18 @@ simde_int16x8x3_t
 simde_vld3q_s16(int16_t const *ptr) {
   #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
     return vld3q_s16(ptr);
+  #elif defined(SIMDE_RISCV_V_NATIVE) && (SIMDE_NATURAL_VECTOR_SIZE >= 128)
+    simde_int16x8_private r_[3];
+    vint16m1x3_t dest = __riscv_vlseg3e16_v_i16m1x3(&ptr[0], 8);
+    r_[0].sv128 = __riscv_vget_v_i16m1x3_i16m1(dest, 0);
+    r_[1].sv128 = __riscv_vget_v_i16m1x3_i16m1(dest, 1);
+    r_[2].sv128 = __riscv_vget_v_i16m1x3_i16m1(dest, 2);
+    simde_int16x8x3_t r = { {
+      simde_int16x8_from_private(r_[0]),
+      simde_int16x8_from_private(r_[1]),
+      simde_int16x8_from_private(r_[2])
+    } };
+    return r;
   #else
     simde_int16x8_private r_[3];
 
@@ -494,6 +603,18 @@ simde_int32x4x3_t
 simde_vld3q_s32(int32_t const *ptr) {
   #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
     return vld3q_s32(ptr);
+  #elif defined(SIMDE_RISCV_V_NATIVE) && (SIMDE_NATURAL_VECTOR_SIZE >= 128)
+    simde_int32x4_private r_[3];
+    vint32m1x3_t dest = __riscv_vlseg3e32_v_i32m1x3(&ptr[0], 4);
+    r_[0].sv128 = __riscv_vget_v_i32m1x3_i32m1(dest, 0);
+    r_[1].sv128 = __riscv_vget_v_i32m1x3_i32m1(dest, 1);
+    r_[2].sv128 = __riscv_vget_v_i32m1x3_i32m1(dest, 2);
+    simde_int32x4x3_t r = { {
+      simde_int32x4_from_private(r_[0]),
+      simde_int32x4_from_private(r_[1]),
+      simde_int32x4_from_private(r_[2])
+    } };
+    return r;
   #else
     simde_int32x4_private r_[3];
 
@@ -522,6 +643,18 @@ simde_int64x2x3_t
 simde_vld3q_s64(int64_t const *ptr) {
   #if defined(SIMDE_ARM_NEON_A64V8_NATIVE)
     return vld3q_s64(ptr);
+  #elif defined(SIMDE_RISCV_V_NATIVE) && (SIMDE_NATURAL_VECTOR_SIZE >= 128)
+    simde_int64x2_private r_[3];
+    vint64m1x3_t dest = __riscv_vlseg3e64_v_i64m1x3(&ptr[0], 2);
+    r_[0].sv128 = __riscv_vget_v_i64m1x3_i64m1(dest, 0);
+    r_[1].sv128 = __riscv_vget_v_i64m1x3_i64m1(dest, 1);
+    r_[2].sv128 = __riscv_vget_v_i64m1x3_i64m1(dest, 2);
+    simde_int64x2x3_t r = { {
+      simde_int64x2_from_private(r_[0]),
+      simde_int64x2_from_private(r_[1]),
+      simde_int64x2_from_private(r_[2])
+    } };
+    return r;
   #else
     simde_int64x2_private r_[3];
 
@@ -551,6 +684,18 @@ simde_uint8x16x3_t
 simde_vld3q_u8(uint8_t const *ptr) {
   #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
     return vld3q_u8(ptr);
+  #elif defined(SIMDE_RISCV_V_NATIVE) && (SIMDE_NATURAL_VECTOR_SIZE >= 128)
+    simde_uint8x16_private r_[3];
+    vuint8m1x3_t dest = __riscv_vlseg3e8_v_u8m1x3(&ptr[0], 16);
+    r_[0].sv128 = __riscv_vget_v_u8m1x3_u8m1(dest, 0);
+    r_[1].sv128 = __riscv_vget_v_u8m1x3_u8m1(dest, 1);
+    r_[2].sv128 = __riscv_vget_v_u8m1x3_u8m1(dest, 2);
+    simde_uint8x16x3_t r = { {
+      simde_uint8x16_from_private(r_[0]),
+      simde_uint8x16_from_private(r_[1]),
+      simde_uint8x16_from_private(r_[2])
+    } };
+    return r;
   #else
     simde_uint8x16_private r_[3];
 
@@ -579,6 +724,18 @@ simde_uint16x8x3_t
 simde_vld3q_u16(uint16_t const *ptr) {
   #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
     return vld3q_u16(ptr);
+  #elif defined(SIMDE_RISCV_V_NATIVE) && (SIMDE_NATURAL_VECTOR_SIZE >= 128)
+    simde_uint16x8_private r_[3];
+    vuint16m1x3_t dest = __riscv_vlseg3e16_v_u16m1x3(&ptr[0], 8);
+    r_[0].sv128 = __riscv_vget_v_u16m1x3_u16m1(dest, 0);
+    r_[1].sv128 = __riscv_vget_v_u16m1x3_u16m1(dest, 1);
+    r_[2].sv128 = __riscv_vget_v_u16m1x3_u16m1(dest, 2);
+    simde_uint16x8x3_t r = { {
+      simde_uint16x8_from_private(r_[0]),
+      simde_uint16x8_from_private(r_[1]),
+      simde_uint16x8_from_private(r_[2])
+    } };
+    return r;
   #else
     simde_uint16x8_private r_[3];
 
@@ -607,6 +764,18 @@ simde_uint32x4x3_t
 simde_vld3q_u32(uint32_t const *ptr) {
   #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
     return vld3q_u32(ptr);
+  #elif defined(SIMDE_RISCV_V_NATIVE) && (SIMDE_NATURAL_VECTOR_SIZE >= 128)
+    simde_uint32x4_private r_[3];
+    vuint32m1x3_t dest = __riscv_vlseg3e32_v_u32m1x3(&ptr[0], 4);
+    r_[0].sv128 = __riscv_vget_v_u32m1x3_u32m1(dest, 0);
+    r_[1].sv128 = __riscv_vget_v_u32m1x3_u32m1(dest, 1);
+    r_[2].sv128 = __riscv_vget_v_u32m1x3_u32m1(dest, 2);
+    simde_uint32x4x3_t r = { {
+      simde_uint32x4_from_private(r_[0]),
+      simde_uint32x4_from_private(r_[1]),
+      simde_uint32x4_from_private(r_[2])
+    } };
+    return r;
   #else
     simde_uint32x4_private r_[3];
 
@@ -635,6 +804,18 @@ simde_uint64x2x3_t
 simde_vld3q_u64(uint64_t const *ptr) {
   #if defined(SIMDE_ARM_NEON_A64V8_NATIVE)
     return vld3q_u64(ptr);
+  #elif defined(SIMDE_RISCV_V_NATIVE) && (SIMDE_NATURAL_VECTOR_SIZE >= 128)
+    simde_uint64x2_private r_[3];
+    vuint64m1x3_t dest = __riscv_vlseg3e64_v_u64m1x3(&ptr[0], 2);
+    r_[0].sv128 = __riscv_vget_v_u64m1x3_u64m1(dest, 0);
+    r_[1].sv128 = __riscv_vget_v_u64m1x3_u64m1(dest, 1);
+    r_[2].sv128 = __riscv_vget_v_u64m1x3_u64m1(dest, 2);
+    simde_uint64x2x3_t r = { {
+      simde_uint64x2_from_private(r_[0]),
+      simde_uint64x2_from_private(r_[1]),
+      simde_uint64x2_from_private(r_[2])
+    } };
+    return r;
   #else
     simde_uint64x2_private r_[3];
 

--- a/simde/arm/neon/ld4.h
+++ b/simde/arm/neon/ld4.h
@@ -49,11 +49,11 @@ simde_vld4_f16(simde_float16 const ptr[HEDLEY_ARRAY_PARAM(16)]) {
   #else
     simde_float16x4_private a_[4];
     #if defined(SIMDE_RISCV_V_NATIVE) && SIMDE_ARCH_RISCV_ZVFH && (SIMDE_NATURAL_VECTOR_SIZE >= 128)
-      vfloat16mf2x4_t dest = __riscv_vlseg4e16_v_f16mf2x4((_Float16 *)&ptr[0], 4);
-      a_[0].sv64 = __riscv_vget_v_f16mf2x4_f16mf2(dest, 0);
-      a_[1].sv64 = __riscv_vget_v_f16mf2x4_f16mf2(dest, 1);
-      a_[2].sv64 = __riscv_vget_v_f16mf2x4_f16mf2(dest, 2);
-      a_[3].sv64 = __riscv_vget_v_f16mf2x4_f16mf2(dest, 3);
+      vfloat16m1x4_t dest = __riscv_vlseg4e16_v_f16m1x4((_Float16 *)&ptr[0], 4);
+      a_[0].sv64 = __riscv_vget_v_f16m1x4_f16mf2(dest, 0);
+      a_[1].sv64 = __riscv_vget_v_f16m1x4_f16mf2(dest, 1);
+      a_[2].sv64 = __riscv_vget_v_f16m1x4_f16mf2(dest, 2);
+      a_[3].sv64 = __riscv_vget_v_f16m1x4_f16mf2(dest, 3);
     #else
       for (size_t i = 0; i < (sizeof(simde_float16x4_t) / sizeof(*ptr)) * 4 ; i++) {
         a_[i % 4].values[i / 4] = ptr[i];
@@ -77,11 +77,11 @@ simde_vld4_f32(simde_float32 const ptr[HEDLEY_ARRAY_PARAM(8)]) {
   #else
     simde_float32x2_private a_[4];
     #if defined(SIMDE_RISCV_V_NATIVE) && (SIMDE_NATURAL_VECTOR_SIZE >= 128)
-      vfloat32mf2x4_t dest = __riscv_vlseg4e32_v_f32mf2x4(&ptr[0], 2);
-      a_[0].sv64 = __riscv_vget_v_f32mf2x4_f32mf2(dest, 0);
-      a_[1].sv64 = __riscv_vget_v_f32mf2x4_f32mf2(dest, 1);
-      a_[2].sv64 = __riscv_vget_v_f32mf2x4_f32mf2(dest, 2);
-      a_[3].sv64 = __riscv_vget_v_f32mf2x4_f32mf2(dest, 3);
+      vfloat32m1x4_t dest = __riscv_vlseg4e32_v_f32m1x4(&ptr[0], 2);
+      a_[0].sv64 = __riscv_vget_v_f32m1x4_f32m1(dest, 0);
+      a_[1].sv64 = __riscv_vget_v_f32m1x4_f32m1(dest, 1);
+      a_[2].sv64 = __riscv_vget_v_f32m1x4_f32m1(dest, 2);
+      a_[3].sv64 = __riscv_vget_v_f32m1x4_f32m1(dest, 3);
     #else
       for (size_t i = 0; i < (sizeof(simde_float32x2_t) / sizeof(*ptr)) * 4 ; i++) {
         a_[i % 4].values[i / 4] = ptr[i];
@@ -133,11 +133,11 @@ simde_vld4_s8(int8_t const ptr[HEDLEY_ARRAY_PARAM(32)]) {
   #else
     simde_int8x8_private a_[4];
     #if defined(SIMDE_RISCV_V_NATIVE) && (SIMDE_NATURAL_VECTOR_SIZE >= 128)
-      vint8mf2x4_t dest = __riscv_vlseg4e8_v_i8mf2x4(&ptr[0], 8);
-      a_[0].sv64 = __riscv_vget_v_i8mf2x4_i8mf2(dest, 0);
-      a_[1].sv64 = __riscv_vget_v_i8mf2x4_i8mf2(dest, 1);
-      a_[2].sv64 = __riscv_vget_v_i8mf2x4_i8mf2(dest, 2);
-      a_[3].sv64 = __riscv_vget_v_i8mf2x4_i8mf2(dest, 3);
+      vint8m1x4_t dest = __riscv_vlseg4e8_v_i8m1x4(&ptr[0], 8);
+      a_[0].sv64 = __riscv_vget_v_i8m1x4_i8m1(dest, 0);
+      a_[1].sv64 = __riscv_vget_v_i8m1x4_i8m1(dest, 1);
+      a_[2].sv64 = __riscv_vget_v_i8m1x4_i8m1(dest, 2);
+      a_[3].sv64 = __riscv_vget_v_i8m1x4_i8m1(dest, 3);
     #else
       for (size_t i = 0; i < (sizeof(simde_int8x8_t) / sizeof(*ptr)) * 4 ; i++) {
         a_[i % 4].values[i / 4] = ptr[i];
@@ -161,11 +161,11 @@ simde_vld4_s16(int16_t const ptr[HEDLEY_ARRAY_PARAM(16)]) {
   #else
     simde_int16x4_private a_[4];
     #if defined(SIMDE_RISCV_V_NATIVE) && (SIMDE_NATURAL_VECTOR_SIZE >= 128)
-      vint16mf2x4_t dest = __riscv_vlseg4e16_v_i16mf2x4(&ptr[0], 4);
-      a_[0].sv64 = __riscv_vget_v_i16mf2x4_i16mf2(dest, 0);
-      a_[1].sv64 = __riscv_vget_v_i16mf2x4_i16mf2(dest, 1);
-      a_[2].sv64 = __riscv_vget_v_i16mf2x4_i16mf2(dest, 2);
-      a_[3].sv64 = __riscv_vget_v_i16mf2x4_i16mf2(dest, 3);
+      vint16m1x4_t dest = __riscv_vlseg4e16_v_i16m1x4(&ptr[0], 4);
+      a_[0].sv64 = __riscv_vget_v_i16m1x4_i16m1(dest, 0);
+      a_[1].sv64 = __riscv_vget_v_i16m1x4_i16m1(dest, 1);
+      a_[2].sv64 = __riscv_vget_v_i16m1x4_i16m1(dest, 2);
+      a_[3].sv64 = __riscv_vget_v_i16m1x4_i16m1(dest, 3);
     #else
       for (size_t i = 0; i < (sizeof(simde_int16x4_t) / sizeof(*ptr)) * 4 ; i++) {
         a_[i % 4].values[i / 4] = ptr[i];
@@ -189,11 +189,11 @@ simde_vld4_s32(int32_t const ptr[HEDLEY_ARRAY_PARAM(8)]) {
   #else
     simde_int32x2_private a_[4];
     #if defined(SIMDE_RISCV_V_NATIVE) && (SIMDE_NATURAL_VECTOR_SIZE >= 128)
-      vint32mf2x4_t dest = __riscv_vlseg4e32_v_i32mf2x4(&ptr[0], 2);
-      a_[0].sv64 = __riscv_vget_v_i32mf2x4_i32mf2(dest, 0);
-      a_[1].sv64 = __riscv_vget_v_i32mf2x4_i32mf2(dest, 1);
-      a_[2].sv64 = __riscv_vget_v_i32mf2x4_i32mf2(dest, 2);
-      a_[3].sv64 = __riscv_vget_v_i32mf2x4_i32mf2(dest, 3);
+      vint32m1x4_t dest = __riscv_vlseg4e32_v_i32m1x4(&ptr[0], 2);
+      a_[0].sv64 = __riscv_vget_v_i32m1x4_i32m1(dest, 0);
+      a_[1].sv64 = __riscv_vget_v_i32m1x4_i32m1(dest, 1);
+      a_[2].sv64 = __riscv_vget_v_i32m1x4_i32m1(dest, 2);
+      a_[3].sv64 = __riscv_vget_v_i32m1x4_i32m1(dest, 3);
     #else
       for (size_t i = 0; i < (sizeof(simde_int32x2_t) / sizeof(*ptr)) * 4 ; i++) {
         a_[i % 4].values[i / 4] = ptr[i];
@@ -245,11 +245,11 @@ simde_vld4_u8(uint8_t const ptr[HEDLEY_ARRAY_PARAM(32)]) {
   #else
     simde_uint8x8_private a_[4];
     #if defined(SIMDE_RISCV_V_NATIVE) && (SIMDE_NATURAL_VECTOR_SIZE >= 128)
-      vuint8mf2x4_t dest = __riscv_vlseg4e8_v_u8mf2x4(&ptr[0], 8);
-      a_[0].sv64 = __riscv_vget_v_u8mf2x4_u8mf2(dest, 0);
-      a_[1].sv64 = __riscv_vget_v_u8mf2x4_u8mf2(dest, 1);
-      a_[2].sv64 = __riscv_vget_v_u8mf2x4_u8mf2(dest, 2);
-      a_[3].sv64 = __riscv_vget_v_u8mf2x4_u8mf2(dest, 3);
+      vuint8m1x4_t dest = __riscv_vlseg4e8_v_u8m1x4(&ptr[0], 8);
+      a_[0].sv64 = __riscv_vget_v_u8m1x4_u8m1(dest, 0);
+      a_[1].sv64 = __riscv_vget_v_u8m1x4_u8m1(dest, 1);
+      a_[2].sv64 = __riscv_vget_v_u8m1x4_u8m1(dest, 2);
+      a_[3].sv64 = __riscv_vget_v_u8m1x4_u8m1(dest, 3);
     #else
       for (size_t i = 0; i < (sizeof(simde_uint8x8_t) / sizeof(*ptr)) * 4 ; i++) {
         a_[i % 4].values[i / 4] = ptr[i];
@@ -273,11 +273,11 @@ simde_vld4_u16(uint16_t const ptr[HEDLEY_ARRAY_PARAM(16)]) {
   #else
     simde_uint16x4_private a_[4];
     #if defined(SIMDE_RISCV_V_NATIVE) && (SIMDE_NATURAL_VECTOR_SIZE >= 128)
-      vuint16mf2x4_t dest = __riscv_vlseg4e16_v_u16mf2x4(&ptr[0], 4);
-      a_[0].sv64 = __riscv_vget_v_u16mf2x4_u16mf2(dest, 0);
-      a_[1].sv64 = __riscv_vget_v_u16mf2x4_u16mf2(dest, 1);
-      a_[2].sv64 = __riscv_vget_v_u16mf2x4_u16mf2(dest, 2);
-      a_[3].sv64 = __riscv_vget_v_u16mf2x4_u16mf2(dest, 3);
+      vuint16m1x4_t dest = __riscv_vlseg4e16_v_u16m1x4(&ptr[0], 4);
+      a_[0].sv64 = __riscv_vget_v_u16m1x4_u16m1(dest, 0);
+      a_[1].sv64 = __riscv_vget_v_u16m1x4_u16m1(dest, 1);
+      a_[2].sv64 = __riscv_vget_v_u16m1x4_u16m1(dest, 2);
+      a_[3].sv64 = __riscv_vget_v_u16m1x4_u16m1(dest, 3);
     #else
       for (size_t i = 0; i < (sizeof(simde_uint16x4_t) / sizeof(*ptr)) * 4 ; i++) {
         a_[i % 4].values[i / 4] = ptr[i];
@@ -301,11 +301,11 @@ simde_vld4_u32(uint32_t const ptr[HEDLEY_ARRAY_PARAM(8)]) {
   #else
     simde_uint32x2_private a_[4];
     #if defined(SIMDE_RISCV_V_NATIVE) && (SIMDE_NATURAL_VECTOR_SIZE >= 128)
-      vuint32mf2x4_t dest = __riscv_vlseg4e32_v_u32mf2x4(&ptr[0], 2);
-      a_[0].sv64 = __riscv_vget_v_u32mf2x4_u32mf2(dest, 0);
-      a_[1].sv64 = __riscv_vget_v_u32mf2x4_u32mf2(dest, 1);
-      a_[2].sv64 = __riscv_vget_v_u32mf2x4_u32mf2(dest, 2);
-      a_[3].sv64 = __riscv_vget_v_u32mf2x4_u32mf2(dest, 3);
+      vuint32m1x4_t dest = __riscv_vlseg4e32_v_u32m1x4(&ptr[0], 2);
+      a_[0].sv64 = __riscv_vget_v_u32m1x4_u32m1(dest, 0);
+      a_[1].sv64 = __riscv_vget_v_u32m1x4_u32m1(dest, 1);
+      a_[2].sv64 = __riscv_vget_v_u32m1x4_u32m1(dest, 2);
+      a_[3].sv64 = __riscv_vget_v_u32m1x4_u32m1(dest, 3);
     #else
       for (size_t i = 0; i < (sizeof(simde_uint32x2_t) / sizeof(*ptr)) * 4 ; i++) {
         a_[i % 4].values[i / 4] = ptr[i];

--- a/simde/arm/neon/ld4.h
+++ b/simde/arm/neon/ld4.h
@@ -24,6 +24,7 @@
  *   2020      Evan Nemerson <evan@nemerson.com>
  *   2020      Sean Maher <seanptmaher@gmail.com>
  *   2023      Yi-Yen Chung <eric681@andestech.com> (Copyright owned by Andes Technology)
+ *   2023      Chi-Wei Chu <wewe5215@gapp.nthu.edu.tw>
  */
 
 #if !defined(SIMDE_ARM_NEON_LD4_H)
@@ -47,9 +48,17 @@ simde_vld4_f16(simde_float16 const ptr[HEDLEY_ARRAY_PARAM(16)]) {
     return vld4_f16(ptr);
   #else
     simde_float16x4_private a_[4];
-    for (size_t i = 0; i < (sizeof(simde_float16x4_t) / sizeof(*ptr)) * 4 ; i++) {
-      a_[i % 4].values[i / 4] = ptr[i];
-    }
+    #if defined(SIMDE_RISCV_V_NATIVE) && SIMDE_ARCH_RISCV_ZVFH && (SIMDE_NATURAL_VECTOR_SIZE >= 128)
+      vfloat16mf2x4_t dest = __riscv_vlseg4e16_v_f16mf2x4((_Float16 *)&ptr[0], 4);
+      a_[0].sv64 = __riscv_vget_v_f16mf2x4_f16mf2(dest, 0);
+      a_[1].sv64 = __riscv_vget_v_f16mf2x4_f16mf2(dest, 1);
+      a_[2].sv64 = __riscv_vget_v_f16mf2x4_f16mf2(dest, 2);
+      a_[3].sv64 = __riscv_vget_v_f16mf2x4_f16mf2(dest, 3);
+    #else
+      for (size_t i = 0; i < (sizeof(simde_float16x4_t) / sizeof(*ptr)) * 4 ; i++) {
+        a_[i % 4].values[i / 4] = ptr[i];
+      }
+    #endif
     simde_float16x4x4_t s_ = { { simde_float16x4_from_private(a_[0]), simde_float16x4_from_private(a_[1]),
                                  simde_float16x4_from_private(a_[2]), simde_float16x4_from_private(a_[3]) } };
     return (s_);
@@ -67,9 +76,17 @@ simde_vld4_f32(simde_float32 const ptr[HEDLEY_ARRAY_PARAM(8)]) {
     return vld4_f32(ptr);
   #else
     simde_float32x2_private a_[4];
-    for (size_t i = 0; i < (sizeof(simde_float32x2_t) / sizeof(*ptr)) * 4 ; i++) {
-      a_[i % 4].values[i / 4] = ptr[i];
-    }
+    #if defined(SIMDE_RISCV_V_NATIVE) && (SIMDE_NATURAL_VECTOR_SIZE >= 128)
+      vfloat32mf2x4_t dest = __riscv_vlseg4e32_v_f32mf2x4(&ptr[0], 2);
+      a_[0].sv64 = __riscv_vget_v_f32mf2x4_f32mf2(dest, 0);
+      a_[1].sv64 = __riscv_vget_v_f32mf2x4_f32mf2(dest, 1);
+      a_[2].sv64 = __riscv_vget_v_f32mf2x4_f32mf2(dest, 2);
+      a_[3].sv64 = __riscv_vget_v_f32mf2x4_f32mf2(dest, 3);
+    #else
+      for (size_t i = 0; i < (sizeof(simde_float32x2_t) / sizeof(*ptr)) * 4 ; i++) {
+        a_[i % 4].values[i / 4] = ptr[i];
+      }
+    #endif
     simde_float32x2x4_t s_ = { { simde_float32x2_from_private(a_[0]), simde_float32x2_from_private(a_[1]),
                                  simde_float32x2_from_private(a_[2]), simde_float32x2_from_private(a_[3]) } };
     return (s_);
@@ -87,9 +104,17 @@ simde_vld4_f64(simde_float64 const ptr[HEDLEY_ARRAY_PARAM(4)]) {
     return vld4_f64(ptr);
   #else
     simde_float64x1_private a_[4];
-    for (size_t i = 0; i < (sizeof(simde_float64x1_t) / sizeof(*ptr)) * 4 ; i++) {
-      a_[i % 4].values[i / 4] = ptr[i];
-    }
+    #if defined(SIMDE_RISCV_V_NATIVE) && (SIMDE_NATURAL_VECTOR_SIZE >= 128)
+      vfloat64m1x4_t dest = __riscv_vlseg4e64_v_f64m1x4(&ptr[0], 1);
+      a_[0].sv64 = __riscv_vget_v_f64m1x4_f64m1(dest, 0);
+      a_[1].sv64 = __riscv_vget_v_f64m1x4_f64m1(dest, 1);
+      a_[2].sv64 = __riscv_vget_v_f64m1x4_f64m1(dest, 2);
+      a_[3].sv64 = __riscv_vget_v_f64m1x4_f64m1(dest, 3);
+    #else
+      for (size_t i = 0; i < (sizeof(simde_float64x1_t) / sizeof(*ptr)) * 4 ; i++) {
+        a_[i % 4].values[i / 4] = ptr[i];
+      }
+    #endif
     simde_float64x1x4_t s_ = { { simde_float64x1_from_private(a_[0]), simde_float64x1_from_private(a_[1]),
                                  simde_float64x1_from_private(a_[2]), simde_float64x1_from_private(a_[3]) } };
     return s_;
@@ -107,9 +132,17 @@ simde_vld4_s8(int8_t const ptr[HEDLEY_ARRAY_PARAM(32)]) {
     return vld4_s8(ptr);
   #else
     simde_int8x8_private a_[4];
-    for (size_t i = 0; i < (sizeof(simde_int8x8_t) / sizeof(*ptr)) * 4 ; i++) {
-      a_[i % 4].values[i / 4] = ptr[i];
-    }
+    #if defined(SIMDE_RISCV_V_NATIVE) && (SIMDE_NATURAL_VECTOR_SIZE >= 128)
+      vint8mf2x4_t dest = __riscv_vlseg4e8_v_i8mf2x4(&ptr[0], 8);
+      a_[0].sv64 = __riscv_vget_v_i8mf2x4_i8mf2(dest, 0);
+      a_[1].sv64 = __riscv_vget_v_i8mf2x4_i8mf2(dest, 1);
+      a_[2].sv64 = __riscv_vget_v_i8mf2x4_i8mf2(dest, 2);
+      a_[3].sv64 = __riscv_vget_v_i8mf2x4_i8mf2(dest, 3);
+    #else
+      for (size_t i = 0; i < (sizeof(simde_int8x8_t) / sizeof(*ptr)) * 4 ; i++) {
+        a_[i % 4].values[i / 4] = ptr[i];
+      }
+    #endif
     simde_int8x8x4_t s_ = { { simde_int8x8_from_private(a_[0]), simde_int8x8_from_private(a_[1]),
                               simde_int8x8_from_private(a_[2]), simde_int8x8_from_private(a_[3]) } };
     return s_;
@@ -127,9 +160,17 @@ simde_vld4_s16(int16_t const ptr[HEDLEY_ARRAY_PARAM(16)]) {
     return vld4_s16(ptr);
   #else
     simde_int16x4_private a_[4];
-    for (size_t i = 0; i < (sizeof(simde_int16x4_t) / sizeof(*ptr)) * 4 ; i++) {
-      a_[i % 4].values[i / 4] = ptr[i];
-    }
+    #if defined(SIMDE_RISCV_V_NATIVE) && (SIMDE_NATURAL_VECTOR_SIZE >= 128)
+      vint16mf2x4_t dest = __riscv_vlseg4e16_v_i16mf2x4(&ptr[0], 4);
+      a_[0].sv64 = __riscv_vget_v_i16mf2x4_i16mf2(dest, 0);
+      a_[1].sv64 = __riscv_vget_v_i16mf2x4_i16mf2(dest, 1);
+      a_[2].sv64 = __riscv_vget_v_i16mf2x4_i16mf2(dest, 2);
+      a_[3].sv64 = __riscv_vget_v_i16mf2x4_i16mf2(dest, 3);
+    #else
+      for (size_t i = 0; i < (sizeof(simde_int16x4_t) / sizeof(*ptr)) * 4 ; i++) {
+        a_[i % 4].values[i / 4] = ptr[i];
+      }
+    #endif
     simde_int16x4x4_t s_ = { { simde_int16x4_from_private(a_[0]), simde_int16x4_from_private(a_[1]),
                                simde_int16x4_from_private(a_[2]), simde_int16x4_from_private(a_[3]) } };
     return s_;
@@ -147,9 +188,17 @@ simde_vld4_s32(int32_t const ptr[HEDLEY_ARRAY_PARAM(8)]) {
     return vld4_s32(ptr);
   #else
     simde_int32x2_private a_[4];
-    for (size_t i = 0; i < (sizeof(simde_int32x2_t) / sizeof(*ptr)) * 4 ; i++) {
-      a_[i % 4].values[i / 4] = ptr[i];
-    }
+    #if defined(SIMDE_RISCV_V_NATIVE) && (SIMDE_NATURAL_VECTOR_SIZE >= 128)
+      vint32mf2x4_t dest = __riscv_vlseg4e32_v_i32mf2x4(&ptr[0], 2);
+      a_[0].sv64 = __riscv_vget_v_i32mf2x4_i32mf2(dest, 0);
+      a_[1].sv64 = __riscv_vget_v_i32mf2x4_i32mf2(dest, 1);
+      a_[2].sv64 = __riscv_vget_v_i32mf2x4_i32mf2(dest, 2);
+      a_[3].sv64 = __riscv_vget_v_i32mf2x4_i32mf2(dest, 3);
+    #else
+      for (size_t i = 0; i < (sizeof(simde_int32x2_t) / sizeof(*ptr)) * 4 ; i++) {
+        a_[i % 4].values[i / 4] = ptr[i];
+      }
+    #endif
     simde_int32x2x4_t s_ = { { simde_int32x2_from_private(a_[0]), simde_int32x2_from_private(a_[1]),
                                simde_int32x2_from_private(a_[2]), simde_int32x2_from_private(a_[3]) } };
     return s_;
@@ -167,9 +216,17 @@ simde_vld4_s64(int64_t const ptr[HEDLEY_ARRAY_PARAM(4)]) {
     return vld4_s64(ptr);
   #else
     simde_int64x1_private a_[4];
-    for (size_t i = 0; i < (sizeof(simde_int64x1_t) / sizeof(*ptr)) * 4 ; i++) {
-      a_[i % 4].values[i / 4] = ptr[i];
-    }
+    #if defined(SIMDE_RISCV_V_NATIVE) && (SIMDE_NATURAL_VECTOR_SIZE >= 128)
+      vint64m1x4_t dest = __riscv_vlseg4e64_v_i64m1x4(&ptr[0], 1);
+      a_[0].sv64 = __riscv_vget_v_i64m1x4_i64m1(dest, 0);
+      a_[1].sv64 = __riscv_vget_v_i64m1x4_i64m1(dest, 1);
+      a_[2].sv64 = __riscv_vget_v_i64m1x4_i64m1(dest, 2);
+      a_[3].sv64 = __riscv_vget_v_i64m1x4_i64m1(dest, 3);
+    #else
+      for (size_t i = 0; i < (sizeof(simde_int64x1_t) / sizeof(*ptr)) * 4 ; i++) {
+        a_[i % 4].values[i / 4] = ptr[i];
+      }
+    #endif
     simde_int64x1x4_t s_ = { { simde_int64x1_from_private(a_[0]), simde_int64x1_from_private(a_[1]),
                                simde_int64x1_from_private(a_[2]), simde_int64x1_from_private(a_[3]) } };
     return s_;
@@ -187,9 +244,17 @@ simde_vld4_u8(uint8_t const ptr[HEDLEY_ARRAY_PARAM(32)]) {
     return vld4_u8(ptr);
   #else
     simde_uint8x8_private a_[4];
-    for (size_t i = 0; i < (sizeof(simde_uint8x8_t) / sizeof(*ptr)) * 4 ; i++) {
-      a_[i % 4].values[i / 4] = ptr[i];
-    }
+    #if defined(SIMDE_RISCV_V_NATIVE) && (SIMDE_NATURAL_VECTOR_SIZE >= 128)
+      vuint8mf2x4_t dest = __riscv_vlseg4e8_v_u8mf2x4(&ptr[0], 8);
+      a_[0].sv64 = __riscv_vget_v_u8mf2x4_u8mf2(dest, 0);
+      a_[1].sv64 = __riscv_vget_v_u8mf2x4_u8mf2(dest, 1);
+      a_[2].sv64 = __riscv_vget_v_u8mf2x4_u8mf2(dest, 2);
+      a_[3].sv64 = __riscv_vget_v_u8mf2x4_u8mf2(dest, 3);
+    #else
+      for (size_t i = 0; i < (sizeof(simde_uint8x8_t) / sizeof(*ptr)) * 4 ; i++) {
+        a_[i % 4].values[i / 4] = ptr[i];
+      }
+    #endif
     simde_uint8x8x4_t s_ = { { simde_uint8x8_from_private(a_[0]), simde_uint8x8_from_private(a_[1]),
                                simde_uint8x8_from_private(a_[2]), simde_uint8x8_from_private(a_[3]) } };
     return s_;
@@ -207,9 +272,17 @@ simde_vld4_u16(uint16_t const ptr[HEDLEY_ARRAY_PARAM(16)]) {
     return vld4_u16(ptr);
   #else
     simde_uint16x4_private a_[4];
-    for (size_t i = 0; i < (sizeof(simde_uint16x4_t) / sizeof(*ptr)) * 4 ; i++) {
-      a_[i % 4].values[i / 4] = ptr[i];
-    }
+    #if defined(SIMDE_RISCV_V_NATIVE) && (SIMDE_NATURAL_VECTOR_SIZE >= 128)
+      vuint16mf2x4_t dest = __riscv_vlseg4e16_v_u16mf2x4(&ptr[0], 4);
+      a_[0].sv64 = __riscv_vget_v_u16mf2x4_u16mf2(dest, 0);
+      a_[1].sv64 = __riscv_vget_v_u16mf2x4_u16mf2(dest, 1);
+      a_[2].sv64 = __riscv_vget_v_u16mf2x4_u16mf2(dest, 2);
+      a_[3].sv64 = __riscv_vget_v_u16mf2x4_u16mf2(dest, 3);
+    #else
+      for (size_t i = 0; i < (sizeof(simde_uint16x4_t) / sizeof(*ptr)) * 4 ; i++) {
+        a_[i % 4].values[i / 4] = ptr[i];
+      }
+    #endif
     simde_uint16x4x4_t s_ = { { simde_uint16x4_from_private(a_[0]), simde_uint16x4_from_private(a_[1]),
                                 simde_uint16x4_from_private(a_[2]), simde_uint16x4_from_private(a_[3]) } };
     return s_;
@@ -227,9 +300,17 @@ simde_vld4_u32(uint32_t const ptr[HEDLEY_ARRAY_PARAM(8)]) {
     return vld4_u32(ptr);
   #else
     simde_uint32x2_private a_[4];
-    for (size_t i = 0; i < (sizeof(simde_uint32x2_t) / sizeof(*ptr)) * 4 ; i++) {
-      a_[i % 4].values[i / 4] = ptr[i];
-    }
+    #if defined(SIMDE_RISCV_V_NATIVE) && (SIMDE_NATURAL_VECTOR_SIZE >= 128)
+      vuint32mf2x4_t dest = __riscv_vlseg4e32_v_u32mf2x4(&ptr[0], 2);
+      a_[0].sv64 = __riscv_vget_v_u32mf2x4_u32mf2(dest, 0);
+      a_[1].sv64 = __riscv_vget_v_u32mf2x4_u32mf2(dest, 1);
+      a_[2].sv64 = __riscv_vget_v_u32mf2x4_u32mf2(dest, 2);
+      a_[3].sv64 = __riscv_vget_v_u32mf2x4_u32mf2(dest, 3);
+    #else
+      for (size_t i = 0; i < (sizeof(simde_uint32x2_t) / sizeof(*ptr)) * 4 ; i++) {
+        a_[i % 4].values[i / 4] = ptr[i];
+      }
+    #endif
     simde_uint32x2x4_t s_ = { { simde_uint32x2_from_private(a_[0]), simde_uint32x2_from_private(a_[1]),
                                 simde_uint32x2_from_private(a_[2]), simde_uint32x2_from_private(a_[3]) } };
     return s_;
@@ -247,9 +328,17 @@ simde_vld4_u64(uint64_t const ptr[HEDLEY_ARRAY_PARAM(4)]) {
     return vld4_u64(ptr);
   #else
     simde_uint64x1_private a_[4];
-    for (size_t i = 0; i < (sizeof(simde_uint64x1_t) / sizeof(*ptr)) * 4 ; i++) {
-      a_[i % 4].values[i / 4] = ptr[i];
-    }
+    #if defined(SIMDE_RISCV_V_NATIVE) && (SIMDE_NATURAL_VECTOR_SIZE >= 128)
+      vuint64m1x4_t dest = __riscv_vlseg4e64_v_u64m1x4(&ptr[0], 1);
+      a_[0].sv64 = __riscv_vget_v_u64m1x4_u64m1(dest, 0);
+      a_[1].sv64 = __riscv_vget_v_u64m1x4_u64m1(dest, 1);
+      a_[2].sv64 = __riscv_vget_v_u64m1x4_u64m1(dest, 2);
+      a_[3].sv64 = __riscv_vget_v_u64m1x4_u64m1(dest, 3);
+    #else
+      for (size_t i = 0; i < (sizeof(simde_uint64x1_t) / sizeof(*ptr)) * 4 ; i++) {
+        a_[i % 4].values[i / 4] = ptr[i];
+      }
+    #endif
     simde_uint64x1x4_t s_ = { { simde_uint64x1_from_private(a_[0]), simde_uint64x1_from_private(a_[1]),
                                 simde_uint64x1_from_private(a_[2]), simde_uint64x1_from_private(a_[3]) } };
     return s_;
@@ -267,9 +356,17 @@ simde_vld4q_f16(simde_float16 const ptr[HEDLEY_ARRAY_PARAM(32)]) {
     return vld4q_f16(ptr);
   #else
     simde_float16x8_private a_[4];
-    for (size_t i = 0; i < (sizeof(simde_float16x8_t) / sizeof(*ptr)) * 4 ; i++) {
-      a_[i % 4].values[i / 4] = ptr[i];
-    }
+    #if defined(SIMDE_RISCV_V_NATIVE) && SIMDE_ARCH_RISCV_ZVFH && (SIMDE_NATURAL_VECTOR_SIZE >= 128)
+      vfloat16m1x4_t dest = __riscv_vlseg4e16_v_f16m1x4((_Float16 *)&ptr[0], 8);
+      a_[0].sv128 = __riscv_vget_v_f16m1x4_f16m1(dest, 0);
+      a_[1].sv128 = __riscv_vget_v_f16m1x4_f16m1(dest, 1);
+      a_[2].sv128 = __riscv_vget_v_f16m1x4_f16m1(dest, 2);
+      a_[3].sv128 = __riscv_vget_v_f16m1x4_f16m1(dest, 3);
+    #else
+      for (size_t i = 0; i < (sizeof(simde_float16x8_t) / sizeof(*ptr)) * 4 ; i++) {
+        a_[i % 4].values[i / 4] = ptr[i];
+      }
+    #endif
     simde_float16x8x4_t s_ = { { simde_float16x8_from_private(a_[0]), simde_float16x8_from_private(a_[1]),
                                  simde_float16x8_from_private(a_[2]), simde_float16x8_from_private(a_[3]) } };
     return s_;
@@ -287,9 +384,17 @@ simde_vld4q_f32(simde_float32 const ptr[HEDLEY_ARRAY_PARAM(16)]) {
     return vld4q_f32(ptr);
   #else
     simde_float32x4_private a_[4];
-    for (size_t i = 0; i < (sizeof(simde_float32x4_t) / sizeof(*ptr)) * 4 ; i++) {
-      a_[i % 4].values[i / 4] = ptr[i];
-    }
+    #if defined(SIMDE_RISCV_V_NATIVE) && (SIMDE_NATURAL_VECTOR_SIZE >= 128)
+      vfloat32m1x4_t dest = __riscv_vlseg4e32_v_f32m1x4(&ptr[0], 4);
+      a_[0].sv128 = __riscv_vget_v_f32m1x4_f32m1(dest, 0);
+      a_[1].sv128 = __riscv_vget_v_f32m1x4_f32m1(dest, 1);
+      a_[2].sv128 = __riscv_vget_v_f32m1x4_f32m1(dest, 2);
+      a_[3].sv128 = __riscv_vget_v_f32m1x4_f32m1(dest, 3);
+    #else
+      for (size_t i = 0; i < (sizeof(simde_float32x4_t) / sizeof(*ptr)) * 4 ; i++) {
+        a_[i % 4].values[i / 4] = ptr[i];
+      }
+    #endif
     simde_float32x4x4_t s_ = { { simde_float32x4_from_private(a_[0]), simde_float32x4_from_private(a_[1]),
                                  simde_float32x4_from_private(a_[2]), simde_float32x4_from_private(a_[3]) } };
     return s_;
@@ -307,9 +412,17 @@ simde_vld4q_f64(simde_float64 const ptr[HEDLEY_ARRAY_PARAM(8)]) {
     return vld4q_f64(ptr);
   #else
     simde_float64x2_private a_[4];
-    for (size_t i = 0; i < (sizeof(simde_float64x2_t) / sizeof(*ptr)) * 4 ; i++) {
-      a_[i % 4].values[i / 4] = ptr[i];
-    }
+    #if defined(SIMDE_RISCV_V_NATIVE) && (SIMDE_NATURAL_VECTOR_SIZE >= 128)
+      vfloat64m1x4_t dest = __riscv_vlseg4e64_v_f64m1x4(&ptr[0], 2);
+      a_[0].sv128 = __riscv_vget_v_f64m1x4_f64m1(dest, 0);
+      a_[1].sv128 = __riscv_vget_v_f64m1x4_f64m1(dest, 1);
+      a_[2].sv128 = __riscv_vget_v_f64m1x4_f64m1(dest, 2);
+      a_[3].sv128 = __riscv_vget_v_f64m1x4_f64m1(dest, 3);
+    #else
+      for (size_t i = 0; i < (sizeof(simde_float64x2_t) / sizeof(*ptr)) * 4 ; i++) {
+        a_[i % 4].values[i / 4] = ptr[i];
+      }
+    #endif
     simde_float64x2x4_t s_ = { { simde_float64x2_from_private(a_[0]), simde_float64x2_from_private(a_[1]),
                                  simde_float64x2_from_private(a_[2]), simde_float64x2_from_private(a_[3]) } };
     return s_;
@@ -327,9 +440,17 @@ simde_vld4q_s8(int8_t const ptr[HEDLEY_ARRAY_PARAM(64)]) {
     return vld4q_s8(ptr);
   #else
     simde_int8x16_private a_[4];
-    for (size_t i = 0; i < (sizeof(simde_int8x16_t) / sizeof(*ptr)) * 4 ; i++) {
-      a_[i % 4].values[i / 4] = ptr[i];
-    }
+    #if defined(SIMDE_RISCV_V_NATIVE) && (SIMDE_NATURAL_VECTOR_SIZE >= 128)
+      vint8m1x4_t dest = __riscv_vlseg4e8_v_i8m1x4(&ptr[0], 16);
+      a_[0].sv128 = __riscv_vget_v_i8m1x4_i8m1(dest, 0);
+      a_[1].sv128 = __riscv_vget_v_i8m1x4_i8m1(dest, 1);
+      a_[2].sv128 = __riscv_vget_v_i8m1x4_i8m1(dest, 2);
+      a_[3].sv128 = __riscv_vget_v_i8m1x4_i8m1(dest, 3);
+    #else
+      for (size_t i = 0; i < (sizeof(simde_int8x16_t) / sizeof(*ptr)) * 4 ; i++) {
+        a_[i % 4].values[i / 4] = ptr[i];
+      }
+    #endif
     simde_int8x16x4_t s_ = { { simde_int8x16_from_private(a_[0]), simde_int8x16_from_private(a_[1]),
                                simde_int8x16_from_private(a_[2]), simde_int8x16_from_private(a_[3]) } };
     return s_;
@@ -347,9 +468,17 @@ simde_vld4q_s16(int16_t const ptr[HEDLEY_ARRAY_PARAM(32)]) {
     return vld4q_s16(ptr);
   #else
     simde_int16x8_private a_[4];
-    for (size_t i = 0; i < (sizeof(simde_int16x8_t) / sizeof(*ptr)) * 4 ; i++) {
-      a_[i % 4].values[i / 4] = ptr[i];
-    }
+    #if defined(SIMDE_RISCV_V_NATIVE) && (SIMDE_NATURAL_VECTOR_SIZE >= 128)
+      vint16m1x4_t dest = __riscv_vlseg4e16_v_i16m1x4(&ptr[0], 8);
+      a_[0].sv128 = __riscv_vget_v_i16m1x4_i16m1(dest, 0);
+      a_[1].sv128 = __riscv_vget_v_i16m1x4_i16m1(dest, 1);
+      a_[2].sv128 = __riscv_vget_v_i16m1x4_i16m1(dest, 2);
+      a_[3].sv128 = __riscv_vget_v_i16m1x4_i16m1(dest, 3);
+    #else
+      for (size_t i = 0; i < (sizeof(simde_int16x8_t) / sizeof(*ptr)) * 4 ; i++) {
+        a_[i % 4].values[i / 4] = ptr[i];
+      }
+    #endif
     simde_int16x8x4_t s_ = { { simde_int16x8_from_private(a_[0]), simde_int16x8_from_private(a_[1]),
                                simde_int16x8_from_private(a_[2]), simde_int16x8_from_private(a_[3]) } };
     return s_;
@@ -367,9 +496,17 @@ simde_vld4q_s32(int32_t const ptr[HEDLEY_ARRAY_PARAM(16)]) {
     return vld4q_s32(ptr);
   #else
     simde_int32x4_private a_[4];
-    for (size_t i = 0; i < (sizeof(simde_int32x4_t) / sizeof(*ptr)) * 4 ; i++) {
-      a_[i % 4].values[i / 4] = ptr[i];
-    }
+    #if defined(SIMDE_RISCV_V_NATIVE) && (SIMDE_NATURAL_VECTOR_SIZE >= 128)
+      vint32m1x4_t dest = __riscv_vlseg4e32_v_i32m1x4(&ptr[0], 4);
+      a_[0].sv128 = __riscv_vget_v_i32m1x4_i32m1(dest, 0);
+      a_[1].sv128 = __riscv_vget_v_i32m1x4_i32m1(dest, 1);
+      a_[2].sv128 = __riscv_vget_v_i32m1x4_i32m1(dest, 2);
+      a_[3].sv128 = __riscv_vget_v_i32m1x4_i32m1(dest, 3);
+    #else
+      for (size_t i = 0; i < (sizeof(simde_int32x4_t) / sizeof(*ptr)) * 4 ; i++) {
+        a_[i % 4].values[i / 4] = ptr[i];
+      }
+    #endif
     simde_int32x4x4_t s_ = { { simde_int32x4_from_private(a_[0]), simde_int32x4_from_private(a_[1]),
                                simde_int32x4_from_private(a_[2]), simde_int32x4_from_private(a_[3]) } };
     return s_;
@@ -387,9 +524,17 @@ simde_vld4q_s64(int64_t const ptr[HEDLEY_ARRAY_PARAM(8)]) {
     return vld4q_s64(ptr);
   #else
     simde_int64x2_private a_[4];
-    for (size_t i = 0; i < (sizeof(simde_int64x2_t) / sizeof(*ptr)) * 4 ; i++) {
-      a_[i % 4].values[i / 4] = ptr[i];
-    }
+    #if defined(SIMDE_RISCV_V_NATIVE) && (SIMDE_NATURAL_VECTOR_SIZE >= 128)
+      vint64m1x4_t dest = __riscv_vlseg4e64_v_i64m1x4(&ptr[0], 2);
+      a_[0].sv128 = __riscv_vget_v_i64m1x4_i64m1(dest, 0);
+      a_[1].sv128 = __riscv_vget_v_i64m1x4_i64m1(dest, 1);
+      a_[2].sv128 = __riscv_vget_v_i64m1x4_i64m1(dest, 2);
+      a_[3].sv128 = __riscv_vget_v_i64m1x4_i64m1(dest, 3);
+    #else
+      for (size_t i = 0; i < (sizeof(simde_int64x2_t) / sizeof(*ptr)) * 4 ; i++) {
+        a_[i % 4].values[i / 4] = ptr[i];
+      }
+    #endif
     simde_int64x2x4_t s_ = { { simde_int64x2_from_private(a_[0]), simde_int64x2_from_private(a_[1]),
                                simde_int64x2_from_private(a_[2]), simde_int64x2_from_private(a_[3]) } };
     return s_;
@@ -444,6 +589,20 @@ simde_vld4q_u8(uint8_t const ptr[HEDLEY_ARRAY_PARAM(64)]) {
                               simde_uint8x16_from_private(r_[2]),
                               simde_uint8x16_from_private(r_[3])}};
     return s_;
+  #elif defined(SIMDE_RISCV_V_NATIVE) && (SIMDE_NATURAL_VECTOR_SIZE >= 128)
+    simde_uint8x16_private r_[4];
+    vuint8m1x4_t dest = __riscv_vlseg4e8_v_u8m1x4(&ptr[0], 16);
+    r_[0].sv128 = __riscv_vget_v_u8m1x4_u8m1(dest, 0);
+    r_[1].sv128 = __riscv_vget_v_u8m1x4_u8m1(dest, 1);
+    r_[2].sv128 = __riscv_vget_v_u8m1x4_u8m1(dest, 2);
+    r_[3].sv128 = __riscv_vget_v_u8m1x4_u8m1(dest, 3);
+    simde_uint8x16x4_t r = { {
+      simde_uint8x16_from_private(r_[0]),
+      simde_uint8x16_from_private(r_[1]),
+      simde_uint8x16_from_private(r_[2]),
+      simde_uint8x16_from_private(r_[3])
+    } };
+    return r;
   #else
     simde_uint8x16_private a_[4];
     for (size_t i = 0; i < (sizeof(simde_uint8x16_t) / sizeof(*ptr)) * 4 ; i++) {
@@ -466,9 +625,17 @@ simde_vld4q_u16(uint16_t const ptr[HEDLEY_ARRAY_PARAM(32)]) {
     return vld4q_u16(ptr);
   #else
     simde_uint16x8_private a_[4];
-    for (size_t i = 0; i < (sizeof(simde_uint16x8_t) / sizeof(*ptr)) * 4 ; i++) {
-      a_[i % 4].values[i / 4] = ptr[i];
-    }
+    #if defined(SIMDE_RISCV_V_NATIVE) && (SIMDE_NATURAL_VECTOR_SIZE >= 128)
+      vuint16m1x4_t dest = __riscv_vlseg4e16_v_u16m1x4(&ptr[0], 8);
+      a_[0].sv128 = __riscv_vget_v_u16m1x4_u16m1(dest, 0);
+      a_[1].sv128 = __riscv_vget_v_u16m1x4_u16m1(dest, 1);
+      a_[2].sv128 = __riscv_vget_v_u16m1x4_u16m1(dest, 2);
+      a_[3].sv128 = __riscv_vget_v_u16m1x4_u16m1(dest, 3);
+    #else
+      for (size_t i = 0; i < (sizeof(simde_uint16x8_t) / sizeof(*ptr)) * 4 ; i++) {
+        a_[i % 4].values[i / 4] = ptr[i];
+      }
+    #endif
     simde_uint16x8x4_t s_ = { { simde_uint16x8_from_private(a_[0]), simde_uint16x8_from_private(a_[1]),
                                 simde_uint16x8_from_private(a_[2]), simde_uint16x8_from_private(a_[3]) } };
     return s_;
@@ -486,9 +653,17 @@ simde_vld4q_u32(uint32_t const ptr[HEDLEY_ARRAY_PARAM(16)]) {
     return vld4q_u32(ptr);
   #else
     simde_uint32x4_private a_[4];
-    for (size_t i = 0; i < (sizeof(simde_uint32x4_t) / sizeof(*ptr)) * 4 ; i++) {
-      a_[i % 4].values[i / 4] = ptr[i];
-    }
+    #if defined(SIMDE_RISCV_V_NATIVE) && (SIMDE_NATURAL_VECTOR_SIZE >= 128)
+      vuint32m1x4_t dest = __riscv_vlseg4e32_v_u32m1x4(&ptr[0], 4);
+      a_[0].sv128 = __riscv_vget_v_u32m1x4_u32m1(dest, 0);
+      a_[1].sv128 = __riscv_vget_v_u32m1x4_u32m1(dest, 1);
+      a_[2].sv128 = __riscv_vget_v_u32m1x4_u32m1(dest, 2);
+      a_[3].sv128 = __riscv_vget_v_u32m1x4_u32m1(dest, 3);
+    #else
+      for (size_t i = 0; i < (sizeof(simde_uint32x4_t) / sizeof(*ptr)) * 4 ; i++) {
+        a_[i % 4].values[i / 4] = ptr[i];
+      }
+    #endif
     simde_uint32x4x4_t s_ = { { simde_uint32x4_from_private(a_[0]), simde_uint32x4_from_private(a_[1]),
                                 simde_uint32x4_from_private(a_[2]), simde_uint32x4_from_private(a_[3]) } };
     return s_;
@@ -506,9 +681,17 @@ simde_vld4q_u64(uint64_t const ptr[HEDLEY_ARRAY_PARAM(8)]) {
     return vld4q_u64(ptr);
   #else
     simde_uint64x2_private a_[4];
-    for (size_t i = 0; i < (sizeof(simde_uint64x2_t) / sizeof(*ptr)) * 4 ; i++) {
-      a_[i % 4].values[i / 4] = ptr[i];
-    }
+    #if defined(SIMDE_RISCV_V_NATIVE) && (SIMDE_NATURAL_VECTOR_SIZE >= 128)
+      vuint64m1x4_t dest = __riscv_vlseg4e64_v_u64m1x4(&ptr[0], 2);
+      a_[0].sv128 = __riscv_vget_v_u64m1x4_u64m1(dest, 0);
+      a_[1].sv128 = __riscv_vget_v_u64m1x4_u64m1(dest, 1);
+      a_[2].sv128 = __riscv_vget_v_u64m1x4_u64m1(dest, 2);
+      a_[3].sv128 = __riscv_vget_v_u64m1x4_u64m1(dest, 3);
+    #else
+      for (size_t i = 0; i < (sizeof(simde_uint64x2_t) / sizeof(*ptr)) * 4 ; i++) {
+        a_[i % 4].values[i / 4] = ptr[i];
+      }
+    #endif
     simde_uint64x2x4_t s_ = { { simde_uint64x2_from_private(a_[0]), simde_uint64x2_from_private(a_[1]),
                                 simde_uint64x2_from_private(a_[2]), simde_uint64x2_from_private(a_[3]) } };
     return s_;

--- a/simde/arm/neon/ld4.h
+++ b/simde/arm/neon/ld4.h
@@ -50,10 +50,10 @@ simde_vld4_f16(simde_float16 const ptr[HEDLEY_ARRAY_PARAM(16)]) {
     simde_float16x4_private a_[4];
     #if defined(SIMDE_RISCV_V_NATIVE) && SIMDE_ARCH_RISCV_ZVFH && (SIMDE_NATURAL_VECTOR_SIZE >= 128)
       vfloat16m1x4_t dest = __riscv_vlseg4e16_v_f16m1x4((_Float16 *)&ptr[0], 4);
-      a_[0].sv64 = __riscv_vget_v_f16m1x4_f16mf2(dest, 0);
-      a_[1].sv64 = __riscv_vget_v_f16m1x4_f16mf2(dest, 1);
-      a_[2].sv64 = __riscv_vget_v_f16m1x4_f16mf2(dest, 2);
-      a_[3].sv64 = __riscv_vget_v_f16m1x4_f16mf2(dest, 3);
+      a_[0].sv64 = __riscv_vget_v_f16m1x4_f16mf1(dest, 0);
+      a_[1].sv64 = __riscv_vget_v_f16m1x4_f16mf1(dest, 1);
+      a_[2].sv64 = __riscv_vget_v_f16m1x4_f16mf1(dest, 2);
+      a_[3].sv64 = __riscv_vget_v_f16m1x4_f16mf1(dest, 3);
     #else
       for (size_t i = 0; i < (sizeof(simde_float16x4_t) / sizeof(*ptr)) * 4 ; i++) {
         a_[i % 4].values[i / 4] = ptr[i];

--- a/simde/arm/neon/ld4.h
+++ b/simde/arm/neon/ld4.h
@@ -50,10 +50,10 @@ simde_vld4_f16(simde_float16 const ptr[HEDLEY_ARRAY_PARAM(16)]) {
     simde_float16x4_private a_[4];
     #if defined(SIMDE_RISCV_V_NATIVE) && SIMDE_ARCH_RISCV_ZVFH && (SIMDE_NATURAL_VECTOR_SIZE >= 128)
       vfloat16m1x4_t dest = __riscv_vlseg4e16_v_f16m1x4((_Float16 *)&ptr[0], 4);
-      a_[0].sv64 = __riscv_vget_v_f16m1x4_f16mf1(dest, 0);
-      a_[1].sv64 = __riscv_vget_v_f16m1x4_f16mf1(dest, 1);
-      a_[2].sv64 = __riscv_vget_v_f16m1x4_f16mf1(dest, 2);
-      a_[3].sv64 = __riscv_vget_v_f16m1x4_f16mf1(dest, 3);
+      a_[0].sv64 = __riscv_vget_v_f16m1x4_f16m1(dest, 0);
+      a_[1].sv64 = __riscv_vget_v_f16m1x4_f16m1(dest, 1);
+      a_[2].sv64 = __riscv_vget_v_f16m1x4_f16m1(dest, 2);
+      a_[3].sv64 = __riscv_vget_v_f16m1x4_f16m1(dest, 3);
     #else
       for (size_t i = 0; i < (sizeof(simde_float16x4_t) / sizeof(*ptr)) * 4 ; i++) {
         a_[i % 4].values[i / 4] = ptr[i];

--- a/simde/arm/neon/ld4.h
+++ b/simde/arm/neon/ld4.h
@@ -76,7 +76,7 @@ simde_vld4_f32(simde_float32 const ptr[HEDLEY_ARRAY_PARAM(8)]) {
     return vld4_f32(ptr);
   #else
     simde_float32x2_private a_[4];
-    #if defined(SIMDE_RISCV_V_NATIVE) && (SIMDE_NATURAL_VECTOR_SIZE >= 128)
+    #if defined(SIMDE_RISCV_V_NATIVE)
       vfloat32m1x4_t dest = __riscv_vlseg4e32_v_f32m1x4(&ptr[0], 2);
       a_[0].sv64 = __riscv_vget_v_f32m1x4_f32m1(dest, 0);
       a_[1].sv64 = __riscv_vget_v_f32m1x4_f32m1(dest, 1);
@@ -104,7 +104,7 @@ simde_vld4_f64(simde_float64 const ptr[HEDLEY_ARRAY_PARAM(4)]) {
     return vld4_f64(ptr);
   #else
     simde_float64x1_private a_[4];
-    #if defined(SIMDE_RISCV_V_NATIVE) && (SIMDE_NATURAL_VECTOR_SIZE >= 128)
+    #if defined(SIMDE_RISCV_V_NATIVE)
       vfloat64m1x4_t dest = __riscv_vlseg4e64_v_f64m1x4(&ptr[0], 1);
       a_[0].sv64 = __riscv_vget_v_f64m1x4_f64m1(dest, 0);
       a_[1].sv64 = __riscv_vget_v_f64m1x4_f64m1(dest, 1);
@@ -132,7 +132,7 @@ simde_vld4_s8(int8_t const ptr[HEDLEY_ARRAY_PARAM(32)]) {
     return vld4_s8(ptr);
   #else
     simde_int8x8_private a_[4];
-    #if defined(SIMDE_RISCV_V_NATIVE) && (SIMDE_NATURAL_VECTOR_SIZE >= 128)
+    #if defined(SIMDE_RISCV_V_NATIVE)
       vint8m1x4_t dest = __riscv_vlseg4e8_v_i8m1x4(&ptr[0], 8);
       a_[0].sv64 = __riscv_vget_v_i8m1x4_i8m1(dest, 0);
       a_[1].sv64 = __riscv_vget_v_i8m1x4_i8m1(dest, 1);
@@ -160,7 +160,7 @@ simde_vld4_s16(int16_t const ptr[HEDLEY_ARRAY_PARAM(16)]) {
     return vld4_s16(ptr);
   #else
     simde_int16x4_private a_[4];
-    #if defined(SIMDE_RISCV_V_NATIVE) && (SIMDE_NATURAL_VECTOR_SIZE >= 128)
+    #if defined(SIMDE_RISCV_V_NATIVE)
       vint16m1x4_t dest = __riscv_vlseg4e16_v_i16m1x4(&ptr[0], 4);
       a_[0].sv64 = __riscv_vget_v_i16m1x4_i16m1(dest, 0);
       a_[1].sv64 = __riscv_vget_v_i16m1x4_i16m1(dest, 1);
@@ -188,7 +188,7 @@ simde_vld4_s32(int32_t const ptr[HEDLEY_ARRAY_PARAM(8)]) {
     return vld4_s32(ptr);
   #else
     simde_int32x2_private a_[4];
-    #if defined(SIMDE_RISCV_V_NATIVE) && (SIMDE_NATURAL_VECTOR_SIZE >= 128)
+    #if defined(SIMDE_RISCV_V_NATIVE)
       vint32m1x4_t dest = __riscv_vlseg4e32_v_i32m1x4(&ptr[0], 2);
       a_[0].sv64 = __riscv_vget_v_i32m1x4_i32m1(dest, 0);
       a_[1].sv64 = __riscv_vget_v_i32m1x4_i32m1(dest, 1);
@@ -216,7 +216,7 @@ simde_vld4_s64(int64_t const ptr[HEDLEY_ARRAY_PARAM(4)]) {
     return vld4_s64(ptr);
   #else
     simde_int64x1_private a_[4];
-    #if defined(SIMDE_RISCV_V_NATIVE) && (SIMDE_NATURAL_VECTOR_SIZE >= 128)
+    #if defined(SIMDE_RISCV_V_NATIVE)
       vint64m1x4_t dest = __riscv_vlseg4e64_v_i64m1x4(&ptr[0], 1);
       a_[0].sv64 = __riscv_vget_v_i64m1x4_i64m1(dest, 0);
       a_[1].sv64 = __riscv_vget_v_i64m1x4_i64m1(dest, 1);
@@ -244,7 +244,7 @@ simde_vld4_u8(uint8_t const ptr[HEDLEY_ARRAY_PARAM(32)]) {
     return vld4_u8(ptr);
   #else
     simde_uint8x8_private a_[4];
-    #if defined(SIMDE_RISCV_V_NATIVE) && (SIMDE_NATURAL_VECTOR_SIZE >= 128)
+    #if defined(SIMDE_RISCV_V_NATIVE)
       vuint8m1x4_t dest = __riscv_vlseg4e8_v_u8m1x4(&ptr[0], 8);
       a_[0].sv64 = __riscv_vget_v_u8m1x4_u8m1(dest, 0);
       a_[1].sv64 = __riscv_vget_v_u8m1x4_u8m1(dest, 1);
@@ -272,7 +272,7 @@ simde_vld4_u16(uint16_t const ptr[HEDLEY_ARRAY_PARAM(16)]) {
     return vld4_u16(ptr);
   #else
     simde_uint16x4_private a_[4];
-    #if defined(SIMDE_RISCV_V_NATIVE) && (SIMDE_NATURAL_VECTOR_SIZE >= 128)
+    #if defined(SIMDE_RISCV_V_NATIVE)
       vuint16m1x4_t dest = __riscv_vlseg4e16_v_u16m1x4(&ptr[0], 4);
       a_[0].sv64 = __riscv_vget_v_u16m1x4_u16m1(dest, 0);
       a_[1].sv64 = __riscv_vget_v_u16m1x4_u16m1(dest, 1);
@@ -300,7 +300,7 @@ simde_vld4_u32(uint32_t const ptr[HEDLEY_ARRAY_PARAM(8)]) {
     return vld4_u32(ptr);
   #else
     simde_uint32x2_private a_[4];
-    #if defined(SIMDE_RISCV_V_NATIVE) && (SIMDE_NATURAL_VECTOR_SIZE >= 128)
+    #if defined(SIMDE_RISCV_V_NATIVE)
       vuint32m1x4_t dest = __riscv_vlseg4e32_v_u32m1x4(&ptr[0], 2);
       a_[0].sv64 = __riscv_vget_v_u32m1x4_u32m1(dest, 0);
       a_[1].sv64 = __riscv_vget_v_u32m1x4_u32m1(dest, 1);
@@ -328,7 +328,7 @@ simde_vld4_u64(uint64_t const ptr[HEDLEY_ARRAY_PARAM(4)]) {
     return vld4_u64(ptr);
   #else
     simde_uint64x1_private a_[4];
-    #if defined(SIMDE_RISCV_V_NATIVE) && (SIMDE_NATURAL_VECTOR_SIZE >= 128)
+    #if defined(SIMDE_RISCV_V_NATIVE)
       vuint64m1x4_t dest = __riscv_vlseg4e64_v_u64m1x4(&ptr[0], 1);
       a_[0].sv64 = __riscv_vget_v_u64m1x4_u64m1(dest, 0);
       a_[1].sv64 = __riscv_vget_v_u64m1x4_u64m1(dest, 1);
@@ -384,7 +384,7 @@ simde_vld4q_f32(simde_float32 const ptr[HEDLEY_ARRAY_PARAM(16)]) {
     return vld4q_f32(ptr);
   #else
     simde_float32x4_private a_[4];
-    #if defined(SIMDE_RISCV_V_NATIVE) && (SIMDE_NATURAL_VECTOR_SIZE >= 128)
+    #if defined(SIMDE_RISCV_V_NATIVE)
       vfloat32m1x4_t dest = __riscv_vlseg4e32_v_f32m1x4(&ptr[0], 4);
       a_[0].sv128 = __riscv_vget_v_f32m1x4_f32m1(dest, 0);
       a_[1].sv128 = __riscv_vget_v_f32m1x4_f32m1(dest, 1);
@@ -412,7 +412,7 @@ simde_vld4q_f64(simde_float64 const ptr[HEDLEY_ARRAY_PARAM(8)]) {
     return vld4q_f64(ptr);
   #else
     simde_float64x2_private a_[4];
-    #if defined(SIMDE_RISCV_V_NATIVE) && (SIMDE_NATURAL_VECTOR_SIZE >= 128)
+    #if defined(SIMDE_RISCV_V_NATIVE)
       vfloat64m1x4_t dest = __riscv_vlseg4e64_v_f64m1x4(&ptr[0], 2);
       a_[0].sv128 = __riscv_vget_v_f64m1x4_f64m1(dest, 0);
       a_[1].sv128 = __riscv_vget_v_f64m1x4_f64m1(dest, 1);
@@ -440,7 +440,7 @@ simde_vld4q_s8(int8_t const ptr[HEDLEY_ARRAY_PARAM(64)]) {
     return vld4q_s8(ptr);
   #else
     simde_int8x16_private a_[4];
-    #if defined(SIMDE_RISCV_V_NATIVE) && (SIMDE_NATURAL_VECTOR_SIZE >= 128)
+    #if defined(SIMDE_RISCV_V_NATIVE)
       vint8m1x4_t dest = __riscv_vlseg4e8_v_i8m1x4(&ptr[0], 16);
       a_[0].sv128 = __riscv_vget_v_i8m1x4_i8m1(dest, 0);
       a_[1].sv128 = __riscv_vget_v_i8m1x4_i8m1(dest, 1);
@@ -468,7 +468,7 @@ simde_vld4q_s16(int16_t const ptr[HEDLEY_ARRAY_PARAM(32)]) {
     return vld4q_s16(ptr);
   #else
     simde_int16x8_private a_[4];
-    #if defined(SIMDE_RISCV_V_NATIVE) && (SIMDE_NATURAL_VECTOR_SIZE >= 128)
+    #if defined(SIMDE_RISCV_V_NATIVE)
       vint16m1x4_t dest = __riscv_vlseg4e16_v_i16m1x4(&ptr[0], 8);
       a_[0].sv128 = __riscv_vget_v_i16m1x4_i16m1(dest, 0);
       a_[1].sv128 = __riscv_vget_v_i16m1x4_i16m1(dest, 1);
@@ -496,7 +496,7 @@ simde_vld4q_s32(int32_t const ptr[HEDLEY_ARRAY_PARAM(16)]) {
     return vld4q_s32(ptr);
   #else
     simde_int32x4_private a_[4];
-    #if defined(SIMDE_RISCV_V_NATIVE) && (SIMDE_NATURAL_VECTOR_SIZE >= 128)
+    #if defined(SIMDE_RISCV_V_NATIVE)
       vint32m1x4_t dest = __riscv_vlseg4e32_v_i32m1x4(&ptr[0], 4);
       a_[0].sv128 = __riscv_vget_v_i32m1x4_i32m1(dest, 0);
       a_[1].sv128 = __riscv_vget_v_i32m1x4_i32m1(dest, 1);
@@ -524,7 +524,7 @@ simde_vld4q_s64(int64_t const ptr[HEDLEY_ARRAY_PARAM(8)]) {
     return vld4q_s64(ptr);
   #else
     simde_int64x2_private a_[4];
-    #if defined(SIMDE_RISCV_V_NATIVE) && (SIMDE_NATURAL_VECTOR_SIZE >= 128)
+    #if defined(SIMDE_RISCV_V_NATIVE)
       vint64m1x4_t dest = __riscv_vlseg4e64_v_i64m1x4(&ptr[0], 2);
       a_[0].sv128 = __riscv_vget_v_i64m1x4_i64m1(dest, 0);
       a_[1].sv128 = __riscv_vget_v_i64m1x4_i64m1(dest, 1);
@@ -589,7 +589,7 @@ simde_vld4q_u8(uint8_t const ptr[HEDLEY_ARRAY_PARAM(64)]) {
                               simde_uint8x16_from_private(r_[2]),
                               simde_uint8x16_from_private(r_[3])}};
     return s_;
-  #elif defined(SIMDE_RISCV_V_NATIVE) && (SIMDE_NATURAL_VECTOR_SIZE >= 128)
+  #elif defined(SIMDE_RISCV_V_NATIVE)
     simde_uint8x16_private r_[4];
     vuint8m1x4_t dest = __riscv_vlseg4e8_v_u8m1x4(&ptr[0], 16);
     r_[0].sv128 = __riscv_vget_v_u8m1x4_u8m1(dest, 0);
@@ -625,7 +625,7 @@ simde_vld4q_u16(uint16_t const ptr[HEDLEY_ARRAY_PARAM(32)]) {
     return vld4q_u16(ptr);
   #else
     simde_uint16x8_private a_[4];
-    #if defined(SIMDE_RISCV_V_NATIVE) && (SIMDE_NATURAL_VECTOR_SIZE >= 128)
+    #if defined(SIMDE_RISCV_V_NATIVE)
       vuint16m1x4_t dest = __riscv_vlseg4e16_v_u16m1x4(&ptr[0], 8);
       a_[0].sv128 = __riscv_vget_v_u16m1x4_u16m1(dest, 0);
       a_[1].sv128 = __riscv_vget_v_u16m1x4_u16m1(dest, 1);
@@ -653,7 +653,7 @@ simde_vld4q_u32(uint32_t const ptr[HEDLEY_ARRAY_PARAM(16)]) {
     return vld4q_u32(ptr);
   #else
     simde_uint32x4_private a_[4];
-    #if defined(SIMDE_RISCV_V_NATIVE) && (SIMDE_NATURAL_VECTOR_SIZE >= 128)
+    #if defined(SIMDE_RISCV_V_NATIVE)
       vuint32m1x4_t dest = __riscv_vlseg4e32_v_u32m1x4(&ptr[0], 4);
       a_[0].sv128 = __riscv_vget_v_u32m1x4_u32m1(dest, 0);
       a_[1].sv128 = __riscv_vget_v_u32m1x4_u32m1(dest, 1);
@@ -681,7 +681,7 @@ simde_vld4q_u64(uint64_t const ptr[HEDLEY_ARRAY_PARAM(8)]) {
     return vld4q_u64(ptr);
   #else
     simde_uint64x2_private a_[4];
-    #if defined(SIMDE_RISCV_V_NATIVE) && (SIMDE_NATURAL_VECTOR_SIZE >= 128)
+    #if defined(SIMDE_RISCV_V_NATIVE)
       vuint64m1x4_t dest = __riscv_vlseg4e64_v_u64m1x4(&ptr[0], 2);
       a_[0].sv128 = __riscv_vget_v_u64m1x4_u64m1(dest, 0);
       a_[1].sv128 = __riscv_vget_v_u64m1x4_u64m1(dest, 1);

--- a/simde/arm/neon/st1.h
+++ b/simde/arm/neon/st1.h
@@ -40,7 +40,11 @@ simde_vst1_f16(simde_float16_t ptr[HEDLEY_ARRAY_PARAM(4)], simde_float16x4_t val
     vst1_f16(ptr, val);
   #else
     simde_float16x4_private val_ = simde_float16x4_to_private(val);
-    simde_memcpy(ptr, &val_, 8);
+    #if defined(SIMDE_RISCV_V_NATIVE) && SIMDE_ARCH_RISCV_ZVFH
+      __riscv_vse16_v_f16m1((_Float16 *)ptr , val_.sv64 , 4);
+    #else
+      simde_memcpy(ptr, &val_, 8);
+    #endif
   #endif
 }
 #if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
@@ -55,7 +59,11 @@ simde_vst1_f32(simde_float32_t ptr[HEDLEY_ARRAY_PARAM(2)], simde_float32x2_t val
     vst1_f32(ptr, val);
   #else
     simde_float32x2_private val_ = simde_float32x2_to_private(val);
-    simde_memcpy(ptr, &val_, 8);
+    #if defined(SIMDE_RISCV_V_NATIVE)
+      __riscv_vse32_v_f32m1(ptr , val_.sv64 , 2);
+    #else
+      simde_memcpy(ptr, &val_, 8);
+    #endif
   #endif
 }
 #if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
@@ -70,7 +78,11 @@ simde_vst1_f64(simde_float64_t ptr[HEDLEY_ARRAY_PARAM(1)], simde_float64x1_t val
     vst1_f64(ptr, val);
   #else
     simde_float64x1_private val_ = simde_float64x1_to_private(val);
-    simde_memcpy(ptr, &val_, 8);
+    #if defined(SIMDE_RISCV_V_NATIVE)
+      __riscv_vse64_v_f64m1(ptr , val_.sv64 , 1);
+    #else
+      simde_memcpy(ptr, &val_, 8);
+    #endif
   #endif
 }
 #if defined(SIMDE_ARM_NEON_A64V8_ENABLE_NATIVE_ALIASES)
@@ -85,7 +97,11 @@ simde_vst1_s8(int8_t ptr[HEDLEY_ARRAY_PARAM(8)], simde_int8x8_t val) {
     vst1_s8(ptr, val);
   #else
     simde_int8x8_private val_ = simde_int8x8_to_private(val);
-    simde_memcpy(ptr, &val_, 8);
+    #if defined(SIMDE_RISCV_V_NATIVE)
+      __riscv_vse8_v_i8m1(ptr , val_.sv64 , 8);
+    #else
+      simde_memcpy(ptr, &val_, 8);
+    #endif
   #endif
 }
 #if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
@@ -100,7 +116,11 @@ simde_vst1_s16(int16_t ptr[HEDLEY_ARRAY_PARAM(4)], simde_int16x4_t val) {
     vst1_s16(ptr, val);
   #else
     simde_int16x4_private val_ = simde_int16x4_to_private(val);
-    simde_memcpy(ptr, &val_, 8);
+    #if defined(SIMDE_RISCV_V_NATIVE)
+      __riscv_vse16_v_i16m1(ptr , val_.sv64 , 4);
+    #else
+      simde_memcpy(ptr, &val_, 8);
+    #endif
   #endif
 }
 #if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
@@ -115,7 +135,11 @@ simde_vst1_s32(int32_t ptr[HEDLEY_ARRAY_PARAM(2)], simde_int32x2_t val) {
     vst1_s32(ptr, val);
   #else
     simde_int32x2_private val_ = simde_int32x2_to_private(val);
-    simde_memcpy(ptr, &val_, 8);
+    #if defined(SIMDE_RISCV_V_NATIVE)
+      __riscv_vse32_v_i32m1(ptr , val_.sv64 , 2);
+    #else
+      simde_memcpy(ptr, &val_, 8);
+    #endif
   #endif
 }
 #if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
@@ -130,7 +154,11 @@ simde_vst1_s64(int64_t ptr[HEDLEY_ARRAY_PARAM(1)], simde_int64x1_t val) {
     vst1_s64(ptr, val);
   #else
     simde_int64x1_private val_ = simde_int64x1_to_private(val);
-    simde_memcpy(ptr, &val_, 8);
+    #if defined(SIMDE_RISCV_V_NATIVE)
+      __riscv_vse64_v_i64m1(ptr , val_.sv64 , 1);
+    #else
+      simde_memcpy(ptr, &val_, 8);
+    #endif
   #endif
 }
 #if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
@@ -145,7 +173,11 @@ simde_vst1_u8(uint8_t ptr[HEDLEY_ARRAY_PARAM(8)], simde_uint8x8_t val) {
     vst1_u8(ptr, val);
   #else
     simde_uint8x8_private val_ = simde_uint8x8_to_private(val);
-    simde_memcpy(ptr, &val_, 8);
+    #if defined(SIMDE_RISCV_V_NATIVE)
+      __riscv_vse8_v_u8m1(ptr , val_.sv64 , 8);
+    #else
+      simde_memcpy(ptr, &val_, 8);
+    #endif
   #endif
 }
 #if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
@@ -160,7 +192,11 @@ simde_vst1_u16(uint16_t ptr[HEDLEY_ARRAY_PARAM(4)], simde_uint16x4_t val) {
     vst1_u16(ptr, val);
   #else
     simde_uint16x4_private val_ = simde_uint16x4_to_private(val);
-    simde_memcpy(ptr, &val_, 8);
+    #if defined(SIMDE_RISCV_V_NATIVE)
+      __riscv_vse16_v_u16m1(ptr , val_.sv64 , 4);
+    #else
+      simde_memcpy(ptr, &val_, 8);
+    #endif
   #endif
 }
 #if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
@@ -175,7 +211,11 @@ simde_vst1_u32(uint32_t ptr[HEDLEY_ARRAY_PARAM(2)], simde_uint32x2_t val) {
     vst1_u32(ptr, val);
   #else
     simde_uint32x2_private val_ = simde_uint32x2_to_private(val);
-    simde_memcpy(ptr, &val_, 8);
+    #if defined(SIMDE_RISCV_V_NATIVE)
+      __riscv_vse32_v_u32m1(ptr , val_.sv64 , 2);
+    #else
+      simde_memcpy(ptr, &val_, 8);
+    #endif
   #endif
 }
 #if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
@@ -190,7 +230,11 @@ simde_vst1_u64(uint64_t ptr[HEDLEY_ARRAY_PARAM(1)], simde_uint64x1_t val) {
     vst1_u64(ptr, val);
   #else
     simde_uint64x1_private val_ = simde_uint64x1_to_private(val);
-    simde_memcpy(ptr, &val_, 8);
+    #if defined(SIMDE_RISCV_V_NATIVE)
+      __riscv_vse64_v_u64m1(ptr , val_.sv64 , 1);
+    #else
+      simde_memcpy(ptr, &val_, 8);
+    #endif
   #endif
 }
 #if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
@@ -208,6 +252,8 @@ simde_vst1q_f16(simde_float16_t ptr[HEDLEY_ARRAY_PARAM(8)], simde_float16x8_t va
 
     #if defined(SIMDE_WASM_SIMD128_NATIVE)
       wasm_v128_store(ptr, val_.v128);
+    #elif defined(SIMDE_RISCV_V_NATIVE) && SIMDE_ARCH_RISCV_ZVFH
+      __riscv_vse16_v_f16m1((_Float16 *)ptr , val_.sv128 , 8);
     #else
       simde_memcpy(ptr, &val_, 16);
     #endif
@@ -228,6 +274,8 @@ simde_vst1q_f32(simde_float32_t ptr[HEDLEY_ARRAY_PARAM(4)], simde_float32x4_t va
 
     #if defined(SIMDE_WASM_SIMD128_NATIVE)
       wasm_v128_store(ptr, val_.v128);
+    #elif defined(SIMDE_RISCV_V_NATIVE)
+      __riscv_vse32_v_f32m1(ptr , val_.sv128 , 4);
     #else
       simde_memcpy(ptr, &val_, 16);
     #endif
@@ -248,6 +296,8 @@ simde_vst1q_f64(simde_float64_t ptr[HEDLEY_ARRAY_PARAM(2)], simde_float64x2_t va
 
     #if defined(SIMDE_WASM_SIMD128_NATIVE)
       wasm_v128_store(ptr, val_.v128);
+    #elif defined(SIMDE_RISCV_V_NATIVE)
+      __riscv_vse64_v_f64m1(ptr , val_.sv128 , 2);
     #else
       simde_memcpy(ptr, &val_, 16);
     #endif
@@ -268,6 +318,8 @@ simde_vst1q_s8(int8_t ptr[HEDLEY_ARRAY_PARAM(16)], simde_int8x16_t val) {
 
     #if defined(SIMDE_WASM_SIMD128_NATIVE)
       wasm_v128_store(ptr, val_.v128);
+    #elif defined(SIMDE_RISCV_V_NATIVE)
+      __riscv_vse8_v_i8m1(ptr , val_.sv128 , 16);
     #else
       simde_memcpy(ptr, &val_, 16);
     #endif
@@ -288,6 +340,8 @@ simde_vst1q_s16(int16_t ptr[HEDLEY_ARRAY_PARAM(8)], simde_int16x8_t val) {
 
     #if defined(SIMDE_WASM_SIMD128_NATIVE)
       wasm_v128_store(ptr, val_.v128);
+    #elif defined(SIMDE_RISCV_V_NATIVE)
+      __riscv_vse16_v_i16m1(ptr , val_.sv128 , 8);
     #else
       simde_memcpy(ptr, &val_, 16);
     #endif
@@ -308,6 +362,8 @@ simde_vst1q_s32(int32_t ptr[HEDLEY_ARRAY_PARAM(4)], simde_int32x4_t val) {
 
     #if defined(SIMDE_WASM_SIMD128_NATIVE)
       wasm_v128_store(ptr, val_.v128);
+    #elif defined(SIMDE_RISCV_V_NATIVE)
+      __riscv_vse32_v_i32m1(ptr , val_.sv128 , 4);
     #else
       simde_memcpy(ptr, &val_, 16);
     #endif
@@ -328,6 +384,8 @@ simde_vst1q_s64(int64_t ptr[HEDLEY_ARRAY_PARAM(2)], simde_int64x2_t val) {
 
     #if defined(SIMDE_WASM_SIMD128_NATIVE)
       wasm_v128_store(ptr, val_.v128);
+    #elif defined(SIMDE_RISCV_V_NATIVE)
+      __riscv_vse64_v_i64m1(ptr , val_.sv128 , 2);
     #else
       simde_memcpy(ptr, &val_, 16);
     #endif
@@ -348,6 +406,8 @@ simde_vst1q_u8(uint8_t ptr[HEDLEY_ARRAY_PARAM(16)], simde_uint8x16_t val) {
 
     #if defined(SIMDE_WASM_SIMD128_NATIVE)
       wasm_v128_store(ptr, val_.v128);
+    #elif defined(SIMDE_RISCV_V_NATIVE)
+      __riscv_vse8_v_u8m1(ptr , val_.sv128 , 16);
     #else
       simde_memcpy(ptr, &val_, 16);
     #endif
@@ -368,6 +428,8 @@ simde_vst1q_u16(uint16_t ptr[HEDLEY_ARRAY_PARAM(8)], simde_uint16x8_t val) {
 
     #if defined(SIMDE_WASM_SIMD128_NATIVE)
       wasm_v128_store(ptr, val_.v128);
+    #elif defined(SIMDE_RISCV_V_NATIVE)
+      __riscv_vse16_v_u16m1(ptr , val_.sv128 , 8);
     #else
       simde_memcpy(ptr, &val_, 16);
     #endif
@@ -388,6 +450,8 @@ simde_vst1q_u32(uint32_t ptr[HEDLEY_ARRAY_PARAM(4)], simde_uint32x4_t val) {
 
     #if defined(SIMDE_WASM_SIMD128_NATIVE)
       wasm_v128_store(ptr, val_.v128);
+    #elif defined(SIMDE_RISCV_V_NATIVE)
+      __riscv_vse32_v_u32m1(ptr , val_.sv128 , 4);
     #else
       simde_memcpy(ptr, &val_, 16);
     #endif
@@ -408,6 +472,8 @@ simde_vst1q_u64(uint64_t ptr[HEDLEY_ARRAY_PARAM(2)], simde_uint64x2_t val) {
 
     #if defined(SIMDE_WASM_SIMD128_NATIVE)
       wasm_v128_store(ptr, val_.v128);
+    #elif defined(SIMDE_RISCV_V_NATIVE)
+      __riscv_vse64_v_u64m1(ptr , val_.sv128 , 2);
     #else
       simde_memcpy(ptr, &val_, 16);
     #endif

--- a/simde/arm/neon/st1_x2.h
+++ b/simde/arm/neon/st1_x2.h
@@ -24,6 +24,7 @@
  *   2020      Evan Nemerson <evan@nemerson.com>
  *   2021      Décio Luiz Gazzoni Filho <decio@decpp.net>
  *   2023      Yi-Yen Chung <eric681@andestech.com> (Copyright owned by Andes Technology)
+ *   2023      Chi-Wei Chu <wewe5215@gapp.nthu.edu.tw>
  */
 
 #if !defined(SIMDE_ARM_NEON_ST1_X2_H)
@@ -43,13 +44,18 @@ simde_vst1_f16_x2(simde_float16_t ptr[HEDLEY_ARRAY_PARAM(8)], simde_float16x4x2_
   #if defined(SIMDE_ARM_NEON_A32V7_NATIVE) && defined(SIMDE_ARM_NEON_FP16) && !defined(SIMDE_BUG_GCC_REV_260989)
     vst1_f16_x2(ptr, val);
   #else
-    simde_float16_t buf[8];
     simde_float16x4_private a_[2] = {simde_float16x4_to_private(val.val[0]),
                                      simde_float16x4_to_private(val.val[1])};
-    for (size_t i = 0; i < 8; i++) {
-      buf[i] = a_[i / 4].values[i % 4];
-    }
-    simde_memcpy(ptr, buf, sizeof(buf));
+    #if defined(SIMDE_RISCV_V_NATIVE) && SIMDE_ARCH_RISCV_ZVFH
+      __riscv_vse16_v_f16m1((_Float16 *)ptr , a_[0].sv64 , 4);
+      __riscv_vse16_v_f16m1((_Float16 *)ptr+4 , a_[1].sv64 , 4);
+    #else
+      simde_float16_t buf[8];
+      for (size_t i = 0; i < 8; i++) {
+        buf[i] = a_[i / 4].values[i % 4];
+      }
+      simde_memcpy(ptr, buf, sizeof(buf));
+    #endif
   #endif
 }
 #if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)

--- a/simde/arm/neon/st1_x3.h
+++ b/simde/arm/neon/st1_x3.h
@@ -24,6 +24,7 @@
  *   2020      Evan Nemerson <evan@nemerson.com>
  *   2021      Décio Luiz Gazzoni Filho <decio@decpp.net>
  *   2023      Yi-Yen Chung <eric681@andestech.com> (Copyright owned by Andes Technology)
+ *   2023      Chi-Wei Chu <wewe5215@gapp.nthu.edu.tw>
  */
 
 #if !defined(SIMDE_ARM_NEON_ST1_X3_H)
@@ -46,11 +47,17 @@ simde_vst1_f16_x3(simde_float16_t ptr[HEDLEY_ARRAY_PARAM(12)], simde_float16x4x3
     simde_float16x4_private a[3] = { simde_float16x4_to_private(val.val[0]),
                                       simde_float16x4_to_private(val.val[1]),
                                       simde_float16x4_to_private(val.val[2]) };
-    simde_float16_t buf[12];
-    for (size_t i = 0; i < 12 ; i++) {
-      buf[i] = a[i / 4].values[i % 4];
-    }
-    simde_memcpy(ptr, buf, sizeof(buf));
+    #if defined(SIMDE_RISCV_V_NATIVE) && SIMDE_ARCH_RISCV_ZVFH
+      __riscv_vse16_v_f16m1((_Float16 *)ptr , a[0].sv64 , 4);
+      __riscv_vse16_v_f16m1((_Float16 *)ptr+4 , a[1].sv64 , 4);
+      __riscv_vse16_v_f16m1((_Float16 *)ptr+8 , a[2].sv64 , 4);
+    #else
+      simde_float16_t buf[12];
+      for (size_t i = 0; i < 12 ; i++) {
+        buf[i] = a[i / 4].values[i % 4];
+      }
+      simde_memcpy(ptr, buf, sizeof(buf));
+    #endif
   #endif
 }
 #if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)

--- a/simde/arm/neon/st1_x4.h
+++ b/simde/arm/neon/st1_x4.h
@@ -24,6 +24,7 @@
  *   2020      Evan Nemerson <evan@nemerson.com>
  *   2021      Décio Luiz Gazzoni Filho <decio@decpp.net>
  *   2023      Yi-Yen Chung <eric681@andestech.com> (Copyright owned by Andes Technology)
+ *   2023      Chi-Wei Chu <wewe5215@gapp.nthu.edu.tw>
  */
 
 #if !defined(SIMDE_ARM_NEON_ST1_X4_H)
@@ -43,13 +44,20 @@ simde_vst1_f16_x4(simde_float16_t ptr[HEDLEY_ARRAY_PARAM(16)], simde_float16x4x4
   #if defined(SIMDE_ARM_NEON_A32V7_NATIVE) && defined(SIMDE_ARM_NEON_FP16)
     vst1_f16_x4(ptr, val);
   #else
-    simde_float16_t buf[16];
     simde_float16x4_private a_[4] = { simde_float16x4_to_private(val.val[0]), simde_float16x4_to_private(val.val[1]),
                                       simde_float16x4_to_private(val.val[2]), simde_float16x4_to_private(val.val[3]) };
-    for (size_t i = 0; i < 16 ; i++) {
-      buf[i] = a_[i / 4].values[i % 4];
-    }
-    simde_memcpy(ptr, buf, sizeof(buf));
+    #if defined(SIMDE_RISCV_V_NATIVE) && SIMDE_ARCH_RISCV_ZVFH
+      __riscv_vse16_v_f16m1((_Float16 *)ptr , a_[0].sv64 , 4);
+      __riscv_vse16_v_f16m1((_Float16 *)ptr+4 , a_[1].sv64 , 4);
+      __riscv_vse16_v_f16m1((_Float16 *)ptr+8 , a_[2].sv64 , 4);
+      __riscv_vse16_v_f16m1((_Float16 *)ptr+12 , a_[3].sv64 , 4);
+    #else
+      simde_float16_t buf[16];
+      for (size_t i = 0; i < 16 ; i++) {
+        buf[i] = a_[i / 4].values[i % 4];
+      }
+      simde_memcpy(ptr, buf, sizeof(buf));
+    #endif
   #endif
 }
 #if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)

--- a/simde/arm/neon/st1q_x2.h
+++ b/simde/arm/neon/st1q_x2.h
@@ -22,6 +22,7 @@
  *
  * Copyright:
  *   2023      Yi-Yen Chung <eric681@andestech.com> (Copyright owned by Andes Technology)
+ *   2023      Chi-Wei Chu <wewe5215@gapp.nthu.edu.tw>
  */
 
 #if !defined(SIMDE_ARM_NEON_ST1Q_X2_H)
@@ -41,13 +42,18 @@ simde_vst1q_f16_x2(simde_float16_t ptr[HEDLEY_ARRAY_PARAM(16)], simde_float16x8x
   #if defined(SIMDE_ARM_NEON_A32V7_NATIVE) && defined(SIMDE_ARM_NEON_FP16)
     vst1q_f16_x2(ptr, val);
   #else
-    simde_float16_t buf[16];
     simde_float16x8_private a_[2] = {simde_float16x8_to_private(val.val[0]),
                                      simde_float16x8_to_private(val.val[1])};
-    for (size_t i = 0; i < 16; i++) {
-      buf[i] = a_[i / 8].values[i % 8];
-    }
-    simde_memcpy(ptr, buf, sizeof(buf));
+    #if defined(SIMDE_RISCV_V_NATIVE) && SIMDE_ARCH_RISCV_ZVFH
+      __riscv_vse16_v_f16m1((_Float16 *)ptr , a_[0].sv128 , 8);
+      __riscv_vse16_v_f16m1((_Float16 *)ptr+8 , a_[1].sv128 , 8);
+    #else
+      simde_float16_t buf[16];
+      for (size_t i = 0; i < 16; i++) {
+        buf[i] = a_[i / 8].values[i % 8];
+      }
+      simde_memcpy(ptr, buf, sizeof(buf));
+    #endif
   #endif
 }
 #if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)

--- a/simde/arm/neon/st1q_x3.h
+++ b/simde/arm/neon/st1q_x3.h
@@ -22,6 +22,7 @@
  *
  * Copyright:
  *   2023      Yi-Yen Chung <eric681@andestech.com> (Copyright owned by Andes Technology)
+ *   2023      Chi-Wei Chu <wewe5215@gapp.nthu.edu.tw>
  */
 
 #if !defined(SIMDE_ARM_NEON_ST1Q_X3_H)
@@ -44,11 +45,17 @@ simde_vst1q_f16_x3(simde_float16_t ptr[HEDLEY_ARRAY_PARAM(24)], simde_float16x8x
     simde_float16x8_private a[3] = { simde_float16x8_to_private(val.val[0]),
                                       simde_float16x8_to_private(val.val[1]),
                                       simde_float16x8_to_private(val.val[2]) };
-    simde_float16_t buf[24];
-    for (size_t i = 0; i < 24 ; i++) {
-      buf[i] = a[i / 8].values[i % 8];
-    }
-    simde_memcpy(ptr, buf, sizeof(buf));
+    #if defined(SIMDE_RISCV_V_NATIVE) && SIMDE_ARCH_RISCV_ZVFH
+      __riscv_vse16_v_f16m1((_Float16 *)ptr , a[0].sv128 , 8);
+      __riscv_vse16_v_f16m1((_Float16 *)ptr+8 , a[1].sv128 , 8);
+      __riscv_vse16_v_f16m1((_Float16 *)ptr+16 , a[2].sv128 , 8);
+    #else
+      simde_float16_t buf[24];
+      for (size_t i = 0; i < 24 ; i++) {
+        buf[i] = a[i / 8].values[i % 8];
+      }
+      simde_memcpy(ptr, buf, sizeof(buf));
+    #endif
   #endif
 }
 #if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)

--- a/simde/arm/neon/st1q_x4.h
+++ b/simde/arm/neon/st1q_x4.h
@@ -24,6 +24,7 @@
  *   2020      Evan Nemerson <evan@nemerson.com>
  *   2021      Décio Luiz Gazzoni Filho <decio@decpp.net>
  *   2023      Yi-Yen Chung <eric681@andestech.com> (Copyright owned by Andes Technology)
+ *   2023      Chi-Wei Chu <wewe5215@gapp.nthu.edu.tw>
  */
 
 #if !defined(SIMDE_ARM_NEON_ST1Q_X4_H)
@@ -43,13 +44,20 @@ simde_vst1q_f16_x4(simde_float16_t ptr[HEDLEY_ARRAY_PARAM(32)], simde_float16x8x
   #if defined(SIMDE_ARM_NEON_A32V7_NATIVE) && defined(SIMDE_ARM_NEON_FP16)
     vst1q_f16_x4(ptr, val);
   #else
-    simde_float16_t buf[32];
     simde_float16x8_private a_[4] = { simde_float16x8_to_private(val.val[0]), simde_float16x8_to_private(val.val[1]),
                                       simde_float16x8_to_private(val.val[2]), simde_float16x8_to_private(val.val[3]) };
-    for (size_t i = 0; i < 32 ; i++) {
-      buf[i] = a_[i / 8].values[i % 8];
-    }
-    simde_memcpy(ptr, buf, sizeof(buf));
+    #if defined(SIMDE_RISCV_V_NATIVE) && SIMDE_ARCH_RISCV_ZVFH
+      __riscv_vse16_v_f16m1((_Float16 *)ptr , a_[0].sv128 , 8);
+      __riscv_vse16_v_f16m1((_Float16 *)ptr+8 , a_[1].sv128 , 8);
+      __riscv_vse16_v_f16m1((_Float16 *)ptr+16 , a_[2].sv128 , 8);
+      __riscv_vse16_v_f16m1((_Float16 *)ptr+24 , a_[3].sv128 , 8);
+    #else
+      simde_float16_t buf[32];
+      for (size_t i = 0; i < 32 ; i++) {
+        buf[i] = a_[i / 8].values[i % 8];
+      }
+      simde_memcpy(ptr, buf, sizeof(buf));
+    #endif
   #endif
 }
 #if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)

--- a/simde/arm/neon/st2.h
+++ b/simde/arm/neon/st2.h
@@ -74,7 +74,7 @@ simde_vst2_f32(simde_float32_t *ptr, simde_float32x2x2_t val) {
   #else
     simde_float32x2_private a_[2] = {simde_float32x2_to_private(val.val[0]),
                                      simde_float32x2_to_private(val.val[1])};
-    #if defined(SIMDE_RISCV_V_NATIVE) && (SIMDE_NATURAL_VECTOR_SIZE >= 128)
+    #if defined(SIMDE_RISCV_V_NATIVE)
       vfloat32m1x2_t dest = __riscv_vlseg2e32_v_f32m1x2(ptr, 2);
       dest = __riscv_vset_v_f32m1_f32m1x2 (dest, 0, a_[0].sv64);
       dest = __riscv_vset_v_f32m1_f32m1x2 (dest, 1, a_[1].sv64);
@@ -101,7 +101,7 @@ simde_vst2_f64(simde_float64_t *ptr, simde_float64x1x2_t val) {
   #else
     simde_float64x1_private a_[2] = {simde_float64x1_to_private(val.val[0]),
                                      simde_float64x1_to_private(val.val[1])};
-    #if defined(SIMDE_RISCV_V_NATIVE) && (SIMDE_NATURAL_VECTOR_SIZE >= 128)
+    #if defined(SIMDE_RISCV_V_NATIVE)
       vfloat64m1x2_t dest = __riscv_vlseg2e64_v_f64m1x2(ptr, 1);
       dest = __riscv_vset_v_f64m1_f64m1x2 (dest, 0, a_[0].sv64);
       dest = __riscv_vset_v_f64m1_f64m1x2 (dest, 1, a_[1].sv64);
@@ -128,7 +128,7 @@ simde_vst2_s8(int8_t *ptr, simde_int8x8x2_t val) {
   #else
     simde_int8x8_private a_[2] = {simde_int8x8_to_private(val.val[0]),
                                   simde_int8x8_to_private(val.val[1])};
-    #if defined(SIMDE_RISCV_V_NATIVE) && (SIMDE_NATURAL_VECTOR_SIZE >= 128)
+    #if defined(SIMDE_RISCV_V_NATIVE)
       vint8m1x2_t dest = __riscv_vlseg2e8_v_i8m1x2(ptr, 8);
       dest = __riscv_vset_v_i8m1_i8m1x2 (dest, 0, a_[0].sv64);
       dest = __riscv_vset_v_i8m1_i8m1x2 (dest, 1, a_[1].sv64);
@@ -155,7 +155,7 @@ simde_vst2_s16(int16_t *ptr, simde_int16x4x2_t val) {
   #else
     simde_int16x4_private a_[2] = {simde_int16x4_to_private(val.val[0]),
                                    simde_int16x4_to_private(val.val[1])};
-    #if defined(SIMDE_RISCV_V_NATIVE) && (SIMDE_NATURAL_VECTOR_SIZE >= 128)
+    #if defined(SIMDE_RISCV_V_NATIVE)
       vint16m1x2_t dest = __riscv_vlseg2e16_v_i16m1x2(ptr, 4);
       dest = __riscv_vset_v_i16m1_i16m1x2 (dest, 0, a_[0].sv64);
       dest = __riscv_vset_v_i16m1_i16m1x2 (dest, 1, a_[1].sv64);
@@ -182,7 +182,7 @@ simde_vst2_s32(int32_t *ptr, simde_int32x2x2_t val) {
   #else
     simde_int32x2_private a_[2] = {simde_int32x2_to_private(val.val[0]),
                                    simde_int32x2_to_private(val.val[1])};
-    #if defined(SIMDE_RISCV_V_NATIVE) && (SIMDE_NATURAL_VECTOR_SIZE >= 128)
+    #if defined(SIMDE_RISCV_V_NATIVE)
       vint32m1x2_t dest = __riscv_vlseg2e32_v_i32m1x2(ptr, 2);
       dest = __riscv_vset_v_i32m1_i32m1x2 (dest, 0, a_[0].sv64);
       dest = __riscv_vset_v_i32m1_i32m1x2 (dest, 1, a_[1].sv64);
@@ -209,7 +209,7 @@ simde_vst2_s64(int64_t *ptr, simde_int64x1x2_t val) {
   #else
     simde_int64x1_private a_[2] = {simde_int64x1_to_private(val.val[0]),
                                    simde_int64x1_to_private(val.val[1])};
-    #if defined(SIMDE_RISCV_V_NATIVE) && (SIMDE_NATURAL_VECTOR_SIZE >= 128)
+    #if defined(SIMDE_RISCV_V_NATIVE)
       vint64m1x2_t dest = __riscv_vlseg2e64_v_i64m1x2(ptr, 1);
       dest = __riscv_vset_v_i64m1_i64m1x2 (dest, 0, a_[0].sv64);
       dest = __riscv_vset_v_i64m1_i64m1x2 (dest, 1, a_[1].sv64);
@@ -236,7 +236,7 @@ simde_vst2_u8(uint8_t *ptr, simde_uint8x8x2_t val) {
   #else
     simde_uint8x8_private a_[2] = {simde_uint8x8_to_private(val.val[0]),
                                    simde_uint8x8_to_private(val.val[1])};
-    #if defined(SIMDE_RISCV_V_NATIVE) && (SIMDE_NATURAL_VECTOR_SIZE >= 128)
+    #if defined(SIMDE_RISCV_V_NATIVE)
       vuint8m1x2_t dest = __riscv_vlseg2e8_v_u8m1x2(ptr, 8);
       dest = __riscv_vset_v_u8m1_u8m1x2 (dest, 0, a_[0].sv64);
       dest = __riscv_vset_v_u8m1_u8m1x2 (dest, 1, a_[1].sv64);
@@ -263,7 +263,7 @@ simde_vst2_u16(uint16_t *ptr, simde_uint16x4x2_t val) {
   #else
     simde_uint16x4_private a_[2] = {simde_uint16x4_to_private(val.val[0]),
                                     simde_uint16x4_to_private(val.val[1])};
-    #if defined(SIMDE_RISCV_V_NATIVE) && (SIMDE_NATURAL_VECTOR_SIZE >= 128)
+    #if defined(SIMDE_RISCV_V_NATIVE)
       vuint16m1x2_t dest = __riscv_vlseg2e16_v_u16m1x2(ptr, 4);
       dest = __riscv_vset_v_u16m1_u16m1x2 (dest, 0, a_[0].sv64);
       dest = __riscv_vset_v_u16m1_u16m1x2 (dest, 1, a_[1].sv64);
@@ -290,7 +290,7 @@ simde_vst2_u32(uint32_t *ptr, simde_uint32x2x2_t val) {
   #else
     simde_uint32x2_private a_[2] = {simde_uint32x2_to_private(val.val[0]),
                                     simde_uint32x2_to_private(val.val[1])};
-    #if defined(SIMDE_RISCV_V_NATIVE) && (SIMDE_NATURAL_VECTOR_SIZE >= 128)
+    #if defined(SIMDE_RISCV_V_NATIVE)
       vuint32m1x2_t dest = __riscv_vlseg2e32_v_u32m1x2(ptr, 2);
       dest = __riscv_vset_v_u32m1_u32m1x2 (dest, 0, a_[0].sv64);
       dest = __riscv_vset_v_u32m1_u32m1x2 (dest, 1, a_[1].sv64);
@@ -317,7 +317,7 @@ simde_vst2_u64(uint64_t *ptr, simde_uint64x1x2_t val) {
   #else
     simde_uint64x1_private a_[2] = {simde_uint64x1_to_private(val.val[0]),
                                    simde_uint64x1_to_private(val.val[1])};
-    #if defined(SIMDE_RISCV_V_NATIVE) && (SIMDE_NATURAL_VECTOR_SIZE >= 128)
+    #if defined(SIMDE_RISCV_V_NATIVE)
       vuint64m1x2_t dest = __riscv_vlseg2e64_v_u64m1x2(ptr, 1);
       dest = __riscv_vset_v_u64m1_u64m1x2 (dest, 0, a_[0].sv64);
       dest = __riscv_vset_v_u64m1_u64m1x2 (dest, 1, a_[1].sv64);
@@ -364,7 +364,7 @@ void
 simde_vst2q_f32(simde_float32_t *ptr, simde_float32x4x2_t val) {
   #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
     vst2q_f32(ptr, val);
-  #elif defined(SIMDE_RISCV_V_NATIVE) && (SIMDE_NATURAL_VECTOR_SIZE >= 128)
+  #elif defined(SIMDE_RISCV_V_NATIVE)
     simde_float32x4_private a_[2] = {simde_float32x4_to_private(val.val[0]),
                                      simde_float32x4_to_private(val.val[1])};
     vfloat32m1x2_t dest = __riscv_vlseg2e32_v_f32m1x2(ptr, 4);
@@ -390,7 +390,7 @@ simde_vst2q_f64(simde_float64_t *ptr, simde_float64x2x2_t val) {
   #else
     simde_float64x2_private a_[2] = {simde_float64x2_to_private(val.val[0]),
                                    simde_float64x2_to_private(val.val[1])};
-    #if defined(SIMDE_RISCV_V_NATIVE) && (SIMDE_NATURAL_VECTOR_SIZE >= 128)
+    #if defined(SIMDE_RISCV_V_NATIVE)
       vfloat64m1x2_t dest = __riscv_vlseg2e64_v_f64m1x2(ptr, 2);
       dest = __riscv_vset_v_f64m1_f64m1x2 (dest, 0, a_[0].sv128);
       dest = __riscv_vset_v_f64m1_f64m1x2 (dest, 1, a_[1].sv128);
@@ -414,7 +414,7 @@ void
 simde_vst2q_s8(int8_t *ptr, simde_int8x16x2_t val) {
   #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
     vst2q_s8(ptr, val);
-  #elif defined(SIMDE_RISCV_V_NATIVE) && (SIMDE_NATURAL_VECTOR_SIZE >= 128)
+  #elif defined(SIMDE_RISCV_V_NATIVE)
     simde_int8x16_private a_[2] = {simde_int8x16_to_private(val.val[0]),
                                   simde_int8x16_to_private(val.val[1])};
     vint8m1x2_t dest = __riscv_vlseg2e8_v_i8m1x2(ptr, 16);
@@ -437,7 +437,7 @@ void
 simde_vst2q_s16(int16_t *ptr, simde_int16x8x2_t val) {
   #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
     vst2q_s16(ptr, val);
-  #elif defined(SIMDE_RISCV_V_NATIVE) && (SIMDE_NATURAL_VECTOR_SIZE >= 128)
+  #elif defined(SIMDE_RISCV_V_NATIVE)
     simde_int16x8_private a_[2] = {simde_int16x8_to_private(val.val[0]),
                                    simde_int16x8_to_private(val.val[1])};
     vint16m1x2_t dest = __riscv_vlseg2e16_v_i16m1x2(ptr, 8);
@@ -460,7 +460,7 @@ void
 simde_vst2q_s32(int32_t *ptr, simde_int32x4x2_t val) {
   #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
     vst2q_s32(ptr, val);
-  #elif defined(SIMDE_RISCV_V_NATIVE) && (SIMDE_NATURAL_VECTOR_SIZE >= 128)
+  #elif defined(SIMDE_RISCV_V_NATIVE)
     simde_int32x4_private a_[2] = {simde_int32x4_to_private(val.val[0]),
                                     simde_int32x4_to_private(val.val[1])};
     vint32m1x2_t dest = __riscv_vlseg2e32_v_i32m1x2(ptr, 4);
@@ -483,7 +483,7 @@ void
 simde_vst2q_s64(int64_t *ptr, simde_int64x2x2_t val) {
   #if defined(SIMDE_ARM_NEON_A64V8_NATIVE)
     vst2q_s64(ptr, val);
-  #elif defined(SIMDE_RISCV_V_NATIVE) && (SIMDE_NATURAL_VECTOR_SIZE >= 128)
+  #elif defined(SIMDE_RISCV_V_NATIVE)
     simde_int64x2_private a_[2] = {simde_int64x2_to_private(val.val[0]),
                                    simde_int64x2_to_private(val.val[1])};
     vint64m1x2_t dest = __riscv_vlseg2e64_v_i64m1x2(ptr, 2);
@@ -510,7 +510,7 @@ void
 simde_vst2q_u8(uint8_t *ptr, simde_uint8x16x2_t val) {
   #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
     vst2q_u8(ptr, val);
-  #elif defined(SIMDE_RISCV_V_NATIVE) && (SIMDE_NATURAL_VECTOR_SIZE >= 128)
+  #elif defined(SIMDE_RISCV_V_NATIVE)
     simde_uint8x16_private a_[2] = {simde_uint8x16_to_private(val.val[0]),
                                    simde_uint8x16_to_private(val.val[1])};
     vuint8m1x2_t dest = __riscv_vlseg2e8_v_u8m1x2(ptr, 16);
@@ -533,7 +533,7 @@ void
 simde_vst2q_u16(uint16_t *ptr, simde_uint16x8x2_t val) {
   #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
     vst2q_u16(ptr, val);
-  #elif defined(SIMDE_RISCV_V_NATIVE) && (SIMDE_NATURAL_VECTOR_SIZE >= 128)
+  #elif defined(SIMDE_RISCV_V_NATIVE)
     simde_uint16x8_private a_[2] = {simde_uint16x8_to_private(val.val[0]),
                                     simde_uint16x8_to_private(val.val[1])};
     vuint16m1x2_t dest = __riscv_vlseg2e16_v_u16m1x2(ptr, 8);
@@ -556,7 +556,7 @@ void
 simde_vst2q_u32(uint32_t *ptr, simde_uint32x4x2_t val) {
   #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
     vst2q_u32(ptr, val);
-  #elif defined(SIMDE_RISCV_V_NATIVE) && (SIMDE_NATURAL_VECTOR_SIZE >= 128)
+  #elif defined(SIMDE_RISCV_V_NATIVE)
     simde_uint32x4_private a_[2] = {simde_uint32x4_to_private(val.val[0]),
                                     simde_uint32x4_to_private(val.val[1])};
     vuint32m1x2_t dest = __riscv_vlseg2e32_v_u32m1x2(ptr, 4);
@@ -582,7 +582,7 @@ simde_vst2q_u64(uint64_t *ptr, simde_uint64x2x2_t val) {
   #else
     simde_uint64x2_private a_[2] = {simde_uint64x2_to_private(val.val[0]),
                                    simde_uint64x2_to_private(val.val[1])};
-    #if defined(SIMDE_RISCV_V_NATIVE) && (SIMDE_NATURAL_VECTOR_SIZE >= 128)
+    #if defined(SIMDE_RISCV_V_NATIVE)
       vuint64m1x2_t dest = __riscv_vlseg2e64_v_u64m1x2(ptr, 2);
       dest = __riscv_vset_v_u64m1_u64m1x2 (dest, 0, a_[0].sv128);
       dest = __riscv_vset_v_u64m1_u64m1x2 (dest, 1, a_[1].sv128);

--- a/simde/arm/neon/st2.h
+++ b/simde/arm/neon/st2.h
@@ -24,6 +24,7 @@
  *   2020      Evan Nemerson <evan@nemerson.com>
  *   2021      Zhi An Ng <zhin@google.com> (Copyright owned by Google, LLC)
  *   2023      Yi-Yen Chung <eric681@andestech.com> (Copyright owned by Andes Technology)
+ *   2023      Chi-Wei Chu <wewe5215@gapp.nthu.edu.tw>
  */
 
 #if !defined(SIMDE_ARM_NEON_ST2_H)
@@ -44,13 +45,20 @@ simde_vst2_f16(simde_float16_t *ptr, simde_float16x4x2_t val) {
   #if defined(SIMDE_ARM_NEON_A32V7_NATIVE) && defined(SIMDE_ARM_NEON_FP16)
     vst2_f16(ptr, val);
   #else
-    simde_float16_t buf[8];
     simde_float16x4_private a_[2] = {simde_float16x4_to_private(val.val[0]),
                                      simde_float16x4_to_private(val.val[1])};
-    for (size_t i = 0; i < 8 ; i++) {
-      buf[i] = a_[i % 2].values[i / 2];
-    }
-    simde_memcpy(ptr, buf, sizeof(buf));
+    #if defined(SIMDE_RISCV_V_NATIVE) && SIMDE_ARCH_RISCV_ZVFH && (SIMDE_NATURAL_VECTOR_SIZE >= 128)
+      vfloat16m1x2_t dest = __riscv_vlseg2e16_v_f16m1x2((_Float16 *)ptr, 4);
+      dest = __riscv_vset_v_f16m1_f16m1x2 (dest, 0, a_[0].sv64);
+      dest = __riscv_vset_v_f16m1_f16m1x2 (dest, 1, a_[1].sv64);
+      __riscv_vsseg2e16_v_f16m1x2 ((_Float16 *)ptr, dest, 4);
+    #else
+      simde_float16_t buf[8];
+      for (size_t i = 0; i < 8 ; i++) {
+        buf[i] = a_[i % 2].values[i / 2];
+      }
+      simde_memcpy(ptr, buf, sizeof(buf));
+    #endif
   #endif
 }
 #if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
@@ -64,13 +72,20 @@ simde_vst2_f32(simde_float32_t *ptr, simde_float32x2x2_t val) {
   #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
     vst2_f32(ptr, val);
   #else
-    simde_float32_t buf[4];
     simde_float32x2_private a_[2] = {simde_float32x2_to_private(val.val[0]),
                                      simde_float32x2_to_private(val.val[1])};
-    for (size_t i = 0; i < (sizeof(val.val[0]) / sizeof(*ptr)) * 2 ; i++) {
-      buf[i] = a_[i % 2].values[i / 2];
-    }
-    simde_memcpy(ptr, buf, sizeof(buf));
+    #if defined(SIMDE_RISCV_V_NATIVE) && (SIMDE_NATURAL_VECTOR_SIZE >= 128)
+      vfloat32m1x2_t dest = __riscv_vlseg2e32_v_f32m1x2(ptr, 2);
+      dest = __riscv_vset_v_f32m1_f32m1x2 (dest, 0, a_[0].sv64);
+      dest = __riscv_vset_v_f32m1_f32m1x2 (dest, 1, a_[1].sv64);
+      __riscv_vsseg2e32_v_f32m1x2 (ptr, dest, 2);
+    #else
+      simde_float32_t buf[4];
+      for (size_t i = 0; i < (sizeof(val.val[0]) / sizeof(*ptr)) * 2 ; i++) {
+        buf[i] = a_[i % 2].values[i / 2];
+      }
+      simde_memcpy(ptr, buf, sizeof(buf));
+    #endif
   #endif
 }
 #if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
@@ -84,13 +99,20 @@ simde_vst2_f64(simde_float64_t *ptr, simde_float64x1x2_t val) {
   #if defined(SIMDE_ARM_NEON_A64V8_NATIVE)
     vst2_f64(ptr, val);
   #else
-    simde_float64_t buf[2];
     simde_float64x1_private a_[2] = {simde_float64x1_to_private(val.val[0]),
                                      simde_float64x1_to_private(val.val[1])};
-    for (size_t i = 0; i < (sizeof(val.val[0]) / sizeof(*ptr)) * 2 ; i++) {
-      buf[i] = a_[i % 2].values[i / 2];
-    }
-    simde_memcpy(ptr, buf, sizeof(buf));
+    #if defined(SIMDE_RISCV_V_NATIVE) && (SIMDE_NATURAL_VECTOR_SIZE >= 128)
+      vfloat64m1x2_t dest = __riscv_vlseg2e64_v_f64m1x2(ptr, 1);
+      dest = __riscv_vset_v_f64m1_f64m1x2 (dest, 0, a_[0].sv64);
+      dest = __riscv_vset_v_f64m1_f64m1x2 (dest, 1, a_[1].sv64);
+      __riscv_vsseg2e64_v_f64m1x2 (ptr, dest, 1);
+    #else
+      simde_float64_t buf[2];
+      for (size_t i = 0; i < (sizeof(val.val[0]) / sizeof(*ptr)) * 2 ; i++) {
+        buf[i] = a_[i % 2].values[i / 2];
+      }
+      simde_memcpy(ptr, buf, sizeof(buf));
+    #endif
   #endif
 }
 #if defined(SIMDE_ARM_NEON_A64V8_ENABLE_NATIVE_ALIASES)
@@ -104,13 +126,20 @@ simde_vst2_s8(int8_t *ptr, simde_int8x8x2_t val) {
   #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
     vst2_s8(ptr, val);
   #else
-    int8_t buf[16];
     simde_int8x8_private a_[2] = {simde_int8x8_to_private(val.val[0]),
                                   simde_int8x8_to_private(val.val[1])};
-    for (size_t i = 0; i < (sizeof(val.val[0]) / sizeof(*ptr)) * 2 ; i++) {
-      buf[i] = a_[i % 2].values[i / 2];
-    }
-    simde_memcpy(ptr, buf, sizeof(buf));
+    #if defined(SIMDE_RISCV_V_NATIVE) && (SIMDE_NATURAL_VECTOR_SIZE >= 128)
+      vint8m1x2_t dest = __riscv_vlseg2e8_v_i8m1x2(ptr, 8);
+      dest = __riscv_vset_v_i8m1_i8m1x2 (dest, 0, a_[0].sv64);
+      dest = __riscv_vset_v_i8m1_i8m1x2 (dest, 1, a_[1].sv64);
+      __riscv_vsseg2e8_v_i8m1x2 (ptr, dest, 8);
+    #else
+      int8_t buf[16];
+      for (size_t i = 0; i < (sizeof(val.val[0]) / sizeof(*ptr)) * 2 ; i++) {
+        buf[i] = a_[i % 2].values[i / 2];
+      }
+      simde_memcpy(ptr, buf, sizeof(buf));
+    #endif
   #endif
 }
 #if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
@@ -124,13 +153,20 @@ simde_vst2_s16(int16_t *ptr, simde_int16x4x2_t val) {
   #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
     vst2_s16(ptr, val);
   #else
-    int16_t buf[8];
     simde_int16x4_private a_[2] = {simde_int16x4_to_private(val.val[0]),
                                    simde_int16x4_to_private(val.val[1])};
-    for (size_t i = 0; i < (sizeof(val.val[0]) / sizeof(*ptr)) * 2 ; i++) {
-      buf[i] = a_[i % 2].values[i / 2];
-    }
-    simde_memcpy(ptr, buf, sizeof(buf));
+    #if defined(SIMDE_RISCV_V_NATIVE) && (SIMDE_NATURAL_VECTOR_SIZE >= 128)
+      vint16m1x2_t dest = __riscv_vlseg2e16_v_i16m1x2(ptr, 4);
+      dest = __riscv_vset_v_i16m1_i16m1x2 (dest, 0, a_[0].sv64);
+      dest = __riscv_vset_v_i16m1_i16m1x2 (dest, 1, a_[1].sv64);
+      __riscv_vsseg2e16_v_i16m1x2 (ptr, dest, 4);
+    #else
+      int16_t buf[8];
+      for (size_t i = 0; i < (sizeof(val.val[0]) / sizeof(*ptr)) * 2 ; i++) {
+        buf[i] = a_[i % 2].values[i / 2];
+      }
+      simde_memcpy(ptr, buf, sizeof(buf));
+    #endif
   #endif
 }
 #if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
@@ -144,13 +180,20 @@ simde_vst2_s32(int32_t *ptr, simde_int32x2x2_t val) {
   #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
     vst2_s32(ptr, val);
   #else
-    int32_t buf[4];
     simde_int32x2_private a_[2] = {simde_int32x2_to_private(val.val[0]),
                                    simde_int32x2_to_private(val.val[1])};
-    for (size_t i = 0; i < (sizeof(val.val[0]) / sizeof(*ptr)) * 2 ; i++) {
-      buf[i] = a_[i % 2].values[i / 2];
-    }
-    simde_memcpy(ptr, buf, sizeof(buf));
+    #if defined(SIMDE_RISCV_V_NATIVE) && (SIMDE_NATURAL_VECTOR_SIZE >= 128)
+      vint32m1x2_t dest = __riscv_vlseg2e32_v_i32m1x2(ptr, 2);
+      dest = __riscv_vset_v_i32m1_i32m1x2 (dest, 0, a_[0].sv64);
+      dest = __riscv_vset_v_i32m1_i32m1x2 (dest, 1, a_[1].sv64);
+      __riscv_vsseg2e32_v_i32m1x2 (ptr, dest, 2);
+    #else
+      int32_t buf[4];
+      for (size_t i = 0; i < (sizeof(val.val[0]) / sizeof(*ptr)) * 2 ; i++) {
+        buf[i] = a_[i % 2].values[i / 2];
+      }
+      simde_memcpy(ptr, buf, sizeof(buf));
+    #endif
   #endif
 }
 #if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
@@ -164,13 +207,20 @@ simde_vst2_s64(int64_t *ptr, simde_int64x1x2_t val) {
   #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
     vst2_s64(ptr, val);
   #else
-    int64_t buf[2];
     simde_int64x1_private a_[2] = {simde_int64x1_to_private(val.val[0]),
                                    simde_int64x1_to_private(val.val[1])};
-    for (size_t i = 0; i < (sizeof(val.val[0]) / sizeof(*ptr)) * 2 ; i++) {
-      buf[i] = a_[i % 2].values[i / 2];
-    }
-    simde_memcpy(ptr, buf, sizeof(buf));
+    #if defined(SIMDE_RISCV_V_NATIVE) && (SIMDE_NATURAL_VECTOR_SIZE >= 128)
+      vint64m1x2_t dest = __riscv_vlseg2e64_v_i64m1x2(ptr, 1);
+      dest = __riscv_vset_v_i64m1_i64m1x2 (dest, 0, a_[0].sv64);
+      dest = __riscv_vset_v_i64m1_i64m1x2 (dest, 1, a_[1].sv64);
+      __riscv_vsseg2e64_v_i64m1x2 (ptr, dest, 1);
+    #else
+      int64_t buf[2];
+      for (size_t i = 0; i < (sizeof(val.val[0]) / sizeof(*ptr)) * 2 ; i++) {
+        buf[i] = a_[i % 2].values[i / 2];
+      }
+      simde_memcpy(ptr, buf, sizeof(buf));
+    #endif
   #endif
 }
 #if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
@@ -184,13 +234,20 @@ simde_vst2_u8(uint8_t *ptr, simde_uint8x8x2_t val) {
   #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
     vst2_u8(ptr, val);
   #else
-    uint8_t buf[16];
     simde_uint8x8_private a_[2] = {simde_uint8x8_to_private(val.val[0]),
                                    simde_uint8x8_to_private(val.val[1])};
-    for (size_t i = 0; i < (sizeof(val.val[0]) / sizeof(*ptr)) * 2 ; i++) {
-      buf[i] = a_[i % 2].values[i / 2];
-    }
-    simde_memcpy(ptr, buf, sizeof(buf));
+    #if defined(SIMDE_RISCV_V_NATIVE) && (SIMDE_NATURAL_VECTOR_SIZE >= 128)
+      vuint8m1x2_t dest = __riscv_vlseg2e8_v_u8m1x2(ptr, 8);
+      dest = __riscv_vset_v_u8m1_u8m1x2 (dest, 0, a_[0].sv64);
+      dest = __riscv_vset_v_u8m1_u8m1x2 (dest, 1, a_[1].sv64);
+      __riscv_vsseg2e8_v_u8m1x2 (ptr, dest, 8);
+    #else
+      uint8_t buf[16];
+      for (size_t i = 0; i < (sizeof(val.val[0]) / sizeof(*ptr)) * 2 ; i++) {
+        buf[i] = a_[i % 2].values[i / 2];
+      }
+      simde_memcpy(ptr, buf, sizeof(buf));
+    #endif
   #endif
 }
 #if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
@@ -204,13 +261,20 @@ simde_vst2_u16(uint16_t *ptr, simde_uint16x4x2_t val) {
   #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
     vst2_u16(ptr, val);
   #else
-    uint16_t buf[8];
     simde_uint16x4_private a_[2] = {simde_uint16x4_to_private(val.val[0]),
                                     simde_uint16x4_to_private(val.val[1])};
-    for (size_t i = 0; i < (sizeof(val.val[0]) / sizeof(*ptr)) * 2 ; i++) {
-      buf[i] = a_[i % 2].values[i / 2];
-    }
-    simde_memcpy(ptr, buf, sizeof(buf));
+    #if defined(SIMDE_RISCV_V_NATIVE) && (SIMDE_NATURAL_VECTOR_SIZE >= 128)
+      vuint16m1x2_t dest = __riscv_vlseg2e16_v_u16m1x2(ptr, 4);
+      dest = __riscv_vset_v_u16m1_u16m1x2 (dest, 0, a_[0].sv64);
+      dest = __riscv_vset_v_u16m1_u16m1x2 (dest, 1, a_[1].sv64);
+      __riscv_vsseg2e16_v_u16m1x2 (ptr, dest, 4);
+    #else
+      uint16_t buf[8];
+      for (size_t i = 0; i < (sizeof(val.val[0]) / sizeof(*ptr)) * 2 ; i++) {
+        buf[i] = a_[i % 2].values[i / 2];
+      }
+      simde_memcpy(ptr, buf, sizeof(buf));
+    #endif
   #endif
 }
 #if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
@@ -224,13 +288,20 @@ simde_vst2_u32(uint32_t *ptr, simde_uint32x2x2_t val) {
   #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
     vst2_u32(ptr, val);
   #else
-    uint32_t buf[4];
     simde_uint32x2_private a_[2] = {simde_uint32x2_to_private(val.val[0]),
                                     simde_uint32x2_to_private(val.val[1])};
-    for (size_t i = 0; i < (sizeof(val.val[0]) / sizeof(*ptr)) * 2 ; i++) {
-      buf[i] = a_[i % 2].values[i / 2];
-    }
-    simde_memcpy(ptr, buf, sizeof(buf));
+    #if defined(SIMDE_RISCV_V_NATIVE) && (SIMDE_NATURAL_VECTOR_SIZE >= 128)
+      vuint32m1x2_t dest = __riscv_vlseg2e32_v_u32m1x2(ptr, 2);
+      dest = __riscv_vset_v_u32m1_u32m1x2 (dest, 0, a_[0].sv64);
+      dest = __riscv_vset_v_u32m1_u32m1x2 (dest, 1, a_[1].sv64);
+      __riscv_vsseg2e32_v_u32m1x2 (ptr, dest, 2);
+    #else
+      uint32_t buf[4];
+      for (size_t i = 0; i < (sizeof(val.val[0]) / sizeof(*ptr)) * 2 ; i++) {
+        buf[i] = a_[i % 2].values[i / 2];
+      }
+      simde_memcpy(ptr, buf, sizeof(buf));
+    #endif
   #endif
 }
 #if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
@@ -244,13 +315,20 @@ simde_vst2_u64(uint64_t *ptr, simde_uint64x1x2_t val) {
   #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
     vst2_u64(ptr, val);
   #else
-    uint64_t buf[2];
     simde_uint64x1_private a_[2] = {simde_uint64x1_to_private(val.val[0]),
                                    simde_uint64x1_to_private(val.val[1])};
-    for (size_t i = 0; i < (sizeof(val.val[0]) / sizeof(*ptr)) * 2 ; i++) {
-      buf[i] = a_[i % 2].values[i / 2];
-    }
-    simde_memcpy(ptr, buf, sizeof(buf));
+    #if defined(SIMDE_RISCV_V_NATIVE) && (SIMDE_NATURAL_VECTOR_SIZE >= 128)
+      vuint64m1x2_t dest = __riscv_vlseg2e64_v_u64m1x2(ptr, 1);
+      dest = __riscv_vset_v_u64m1_u64m1x2 (dest, 0, a_[0].sv64);
+      dest = __riscv_vset_v_u64m1_u64m1x2 (dest, 1, a_[1].sv64);
+      __riscv_vsseg2e64_v_u64m1x2 (ptr, dest, 1);
+    #else
+      uint64_t buf[2];
+      for (size_t i = 0; i < (sizeof(val.val[0]) / sizeof(*ptr)) * 2 ; i++) {
+        buf[i] = a_[i % 2].values[i / 2];
+      }
+      simde_memcpy(ptr, buf, sizeof(buf));
+    #endif
   #endif
 }
 #if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
@@ -263,6 +341,13 @@ void
 simde_vst2q_f16(simde_float16_t *ptr, simde_float16x8x2_t val) {
   #if defined(SIMDE_ARM_NEON_A32V7_NATIVE) && defined(SIMDE_ARM_NEON_FP16)
     vst2q_f16(ptr, val);
+  #elif defined(SIMDE_RISCV_V_NATIVE) && SIMDE_ARCH_RISCV_ZVFH && (SIMDE_NATURAL_VECTOR_SIZE >= 128)
+    simde_float16x8_private a_[2] = {simde_float16x8_to_private(val.val[0]),
+                                     simde_float16x8_to_private(val.val[1])};
+    vfloat16m1x2_t dest = __riscv_vlseg2e16_v_f16m1x2((_Float16 *)ptr, 8);
+    dest = __riscv_vset_v_f16m1_f16m1x2 (dest, 0, a_[0].sv128);
+    dest = __riscv_vset_v_f16m1_f16m1x2 (dest, 1, a_[1].sv128);
+    __riscv_vsseg2e16_v_f16m1x2 ((_Float16 *)ptr, dest, 8);
   #else
     simde_float16x8x2_t r = simde_vzipq_f16(val.val[0], val.val[1]);
     simde_vst1q_f16(ptr, r.val[0]);
@@ -279,6 +364,13 @@ void
 simde_vst2q_f32(simde_float32_t *ptr, simde_float32x4x2_t val) {
   #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
     vst2q_f32(ptr, val);
+  #elif defined(SIMDE_RISCV_V_NATIVE) && (SIMDE_NATURAL_VECTOR_SIZE >= 128)
+    simde_float32x4_private a_[2] = {simde_float32x4_to_private(val.val[0]),
+                                     simde_float32x4_to_private(val.val[1])};
+    vfloat32m1x2_t dest = __riscv_vlseg2e32_v_f32m1x2(ptr, 4);
+    dest = __riscv_vset_v_f32m1_f32m1x2 (dest, 0, a_[0].sv128);
+    dest = __riscv_vset_v_f32m1_f32m1x2 (dest, 1, a_[1].sv128);
+    __riscv_vsseg2e32_v_f32m1x2 (ptr, dest, 4);
   #else
     simde_float32x4x2_t r = simde_vzipq_f32(val.val[0], val.val[1]);
     simde_vst1q_f32(ptr, r.val[0]);
@@ -296,13 +388,20 @@ simde_vst2q_f64(simde_float64_t *ptr, simde_float64x2x2_t val) {
   #if defined(SIMDE_ARM_NEON_A64V8_NATIVE)
     vst2q_f64(ptr, val);
   #else
-    simde_float64_t buf[4];
     simde_float64x2_private a_[2] = {simde_float64x2_to_private(val.val[0]),
                                    simde_float64x2_to_private(val.val[1])};
-    for (size_t i = 0; i < (sizeof(val.val[0]) / sizeof(*ptr)) * 2 ; i++) {
-      buf[i] = a_[i % 2].values[i / 2];
-    }
-    simde_memcpy(ptr, buf, sizeof(buf));
+    #if defined(SIMDE_RISCV_V_NATIVE) && (SIMDE_NATURAL_VECTOR_SIZE >= 128)
+      vfloat64m1x2_t dest = __riscv_vlseg2e64_v_f64m1x2(ptr, 2);
+      dest = __riscv_vset_v_f64m1_f64m1x2 (dest, 0, a_[0].sv128);
+      dest = __riscv_vset_v_f64m1_f64m1x2 (dest, 1, a_[1].sv128);
+      __riscv_vsseg2e64_v_f64m1x2 (ptr, dest, 2);
+    #else
+      simde_float64_t buf[4];
+      for (size_t i = 0; i < (sizeof(val.val[0]) / sizeof(*ptr)) * 2 ; i++) {
+        buf[i] = a_[i % 2].values[i / 2];
+      }
+      simde_memcpy(ptr, buf, sizeof(buf));
+    #endif
   #endif
 }
 #if defined(SIMDE_ARM_NEON_A64V8_ENABLE_NATIVE_ALIASES)
@@ -315,6 +414,13 @@ void
 simde_vst2q_s8(int8_t *ptr, simde_int8x16x2_t val) {
   #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
     vst2q_s8(ptr, val);
+  #elif defined(SIMDE_RISCV_V_NATIVE) && (SIMDE_NATURAL_VECTOR_SIZE >= 128)
+    simde_int8x16_private a_[2] = {simde_int8x16_to_private(val.val[0]),
+                                  simde_int8x16_to_private(val.val[1])};
+    vint8m1x2_t dest = __riscv_vlseg2e8_v_i8m1x2(ptr, 16);
+      dest = __riscv_vset_v_i8m1_i8m1x2 (dest, 0, a_[0].sv128);
+      dest = __riscv_vset_v_i8m1_i8m1x2 (dest, 1, a_[1].sv128);
+      __riscv_vsseg2e8_v_i8m1x2 (ptr, dest, 16);
   #else
     simde_int8x16x2_t r = simde_vzipq_s8(val.val[0], val.val[1]);
     simde_vst1q_s8(ptr, r.val[0]);
@@ -331,6 +437,13 @@ void
 simde_vst2q_s16(int16_t *ptr, simde_int16x8x2_t val) {
   #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
     vst2q_s16(ptr, val);
+  #elif defined(SIMDE_RISCV_V_NATIVE) && (SIMDE_NATURAL_VECTOR_SIZE >= 128)
+    simde_int16x8_private a_[2] = {simde_int16x8_to_private(val.val[0]),
+                                   simde_int16x8_to_private(val.val[1])};
+    vint16m1x2_t dest = __riscv_vlseg2e16_v_i16m1x2(ptr, 8);
+      dest = __riscv_vset_v_i16m1_i16m1x2 (dest, 0, a_[0].sv128);
+      dest = __riscv_vset_v_i16m1_i16m1x2 (dest, 1, a_[1].sv128);
+      __riscv_vsseg2e16_v_i16m1x2 (ptr, dest, 8);
   #else
     simde_int16x8x2_t r = simde_vzipq_s16(val.val[0], val.val[1]);
     simde_vst1q_s16(ptr, r.val[0]);
@@ -347,6 +460,13 @@ void
 simde_vst2q_s32(int32_t *ptr, simde_int32x4x2_t val) {
   #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
     vst2q_s32(ptr, val);
+  #elif defined(SIMDE_RISCV_V_NATIVE) && (SIMDE_NATURAL_VECTOR_SIZE >= 128)
+    simde_int32x4_private a_[2] = {simde_int32x4_to_private(val.val[0]),
+                                    simde_int32x4_to_private(val.val[1])};
+    vint32m1x2_t dest = __riscv_vlseg2e32_v_i32m1x2(ptr, 4);
+    dest = __riscv_vset_v_i32m1_i32m1x2 (dest, 0, a_[0].sv128);
+    dest = __riscv_vset_v_i32m1_i32m1x2 (dest, 1, a_[1].sv128);
+    __riscv_vsseg2e32_v_i32m1x2 (ptr, dest, 4);
   #else
     simde_int32x4x2_t r = simde_vzipq_s32(val.val[0], val.val[1]);
     simde_vst1q_s32(ptr, r.val[0]);
@@ -363,6 +483,13 @@ void
 simde_vst2q_s64(int64_t *ptr, simde_int64x2x2_t val) {
   #if defined(SIMDE_ARM_NEON_A64V8_NATIVE)
     vst2q_s64(ptr, val);
+  #elif defined(SIMDE_RISCV_V_NATIVE) && (SIMDE_NATURAL_VECTOR_SIZE >= 128)
+    simde_int64x2_private a_[2] = {simde_int64x2_to_private(val.val[0]),
+                                   simde_int64x2_to_private(val.val[1])};
+    vint64m1x2_t dest = __riscv_vlseg2e64_v_i64m1x2(ptr, 2);
+    dest = __riscv_vset_v_i64m1_i64m1x2 (dest, 0, a_[0].sv128);
+    dest = __riscv_vset_v_i64m1_i64m1x2 (dest, 1, a_[1].sv128);
+    __riscv_vsseg2e64_v_i64m1x2 (ptr, dest, 2);
   #else
     int64_t buf[4];
     simde_int64x2_private a_[2] = {simde_int64x2_to_private(val.val[0]),
@@ -383,6 +510,13 @@ void
 simde_vst2q_u8(uint8_t *ptr, simde_uint8x16x2_t val) {
   #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
     vst2q_u8(ptr, val);
+  #elif defined(SIMDE_RISCV_V_NATIVE) && (SIMDE_NATURAL_VECTOR_SIZE >= 128)
+    simde_uint8x16_private a_[2] = {simde_uint8x16_to_private(val.val[0]),
+                                   simde_uint8x16_to_private(val.val[1])};
+    vuint8m1x2_t dest = __riscv_vlseg2e8_v_u8m1x2(ptr, 16);
+    dest = __riscv_vset_v_u8m1_u8m1x2 (dest, 0, a_[0].sv128);
+    dest = __riscv_vset_v_u8m1_u8m1x2 (dest, 1, a_[1].sv128);
+    __riscv_vsseg2e8_v_u8m1x2 (ptr, dest, 16);
   #else
     simde_uint8x16x2_t r = simde_vzipq_u8(val.val[0], val.val[1]);
     simde_vst1q_u8(ptr, r.val[0]);
@@ -399,6 +533,13 @@ void
 simde_vst2q_u16(uint16_t *ptr, simde_uint16x8x2_t val) {
   #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
     vst2q_u16(ptr, val);
+  #elif defined(SIMDE_RISCV_V_NATIVE) && (SIMDE_NATURAL_VECTOR_SIZE >= 128)
+    simde_uint16x8_private a_[2] = {simde_uint16x8_to_private(val.val[0]),
+                                    simde_uint16x8_to_private(val.val[1])};
+    vuint16m1x2_t dest = __riscv_vlseg2e16_v_u16m1x2(ptr, 8);
+    dest = __riscv_vset_v_u16m1_u16m1x2 (dest, 0, a_[0].sv128);
+    dest = __riscv_vset_v_u16m1_u16m1x2 (dest, 1, a_[1].sv128);
+    __riscv_vsseg2e16_v_u16m1x2 (ptr, dest, 8);
   #else
     simde_uint16x8x2_t r = simde_vzipq_u16(val.val[0], val.val[1]);
     simde_vst1q_u16(ptr, r.val[0]);
@@ -415,6 +556,13 @@ void
 simde_vst2q_u32(uint32_t *ptr, simde_uint32x4x2_t val) {
   #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
     vst2q_u32(ptr, val);
+  #elif defined(SIMDE_RISCV_V_NATIVE) && (SIMDE_NATURAL_VECTOR_SIZE >= 128)
+    simde_uint32x4_private a_[2] = {simde_uint32x4_to_private(val.val[0]),
+                                    simde_uint32x4_to_private(val.val[1])};
+    vuint32m1x2_t dest = __riscv_vlseg2e32_v_u32m1x2(ptr, 4);
+    dest = __riscv_vset_v_u32m1_u32m1x2 (dest, 0, a_[0].sv128);
+    dest = __riscv_vset_v_u32m1_u32m1x2 (dest, 1, a_[1].sv128);
+    __riscv_vsseg2e32_v_u32m1x2 (ptr, dest, 4);
   #else
     simde_uint32x4x2_t r = simde_vzipq_u32(val.val[0], val.val[1]);
     simde_vst1q_u32(ptr, r.val[0]);
@@ -432,13 +580,20 @@ simde_vst2q_u64(uint64_t *ptr, simde_uint64x2x2_t val) {
   #if defined(SIMDE_ARM_NEON_A64V8_NATIVE)
     vst2q_u64(ptr, val);
   #else
-    uint64_t buf[4];
     simde_uint64x2_private a_[2] = {simde_uint64x2_to_private(val.val[0]),
                                    simde_uint64x2_to_private(val.val[1])};
-    for (size_t i = 0; i < (sizeof(val.val[0]) / sizeof(*ptr)) * 2 ; i++) {
-      buf[i] = a_[i % 2].values[i / 2];
-    }
-    simde_memcpy(ptr, buf, sizeof(buf));
+    #if defined(SIMDE_RISCV_V_NATIVE) && (SIMDE_NATURAL_VECTOR_SIZE >= 128)
+      vuint64m1x2_t dest = __riscv_vlseg2e64_v_u64m1x2(ptr, 2);
+      dest = __riscv_vset_v_u64m1_u64m1x2 (dest, 0, a_[0].sv128);
+      dest = __riscv_vset_v_u64m1_u64m1x2 (dest, 1, a_[1].sv128);
+      __riscv_vsseg2e64_v_u64m1x2 (ptr, dest, 2);
+    #else
+      uint64_t buf[4];
+      for (size_t i = 0; i < (sizeof(val.val[0]) / sizeof(*ptr)) * 2 ; i++) {
+        buf[i] = a_[i % 2].values[i / 2];
+      }
+      simde_memcpy(ptr, buf, sizeof(buf));
+    #endif
   #endif
 }
 #if defined(SIMDE_ARM_NEON_A64V8_ENABLE_NATIVE_ALIASES)

--- a/simde/arm/neon/st3.h
+++ b/simde/arm/neon/st3.h
@@ -24,6 +24,7 @@
  *   2020      Evan Nemerson <evan@nemerson.com>
  *   2020      Sean Maher <seanptmaher@gmail.com>
  *   2023      Yi-Yen Chung <eric681@andestech.com> (Copyright owned by Andes Technology)
+ *   2023      Chi-Wei Chu <wewe5215@gapp.nthu.edu.tw>
  */
 
 #if !defined(SIMDE_ARM_NEON_ST3_H)
@@ -47,11 +48,19 @@ simde_vst3_f16(simde_float16_t ptr[HEDLEY_ARRAY_PARAM(12)], simde_float16x4x3_t 
     simde_float16x4_private a[3] = { simde_float16x4_to_private(val.val[0]),
                                       simde_float16x4_to_private(val.val[1]),
                                       simde_float16x4_to_private(val.val[2]) };
-    simde_float16_t buf[12];
-    for (size_t i = 0; i < 12 ; i++) {
-      buf[i] = a[i % 3].values[i / 3];
-    }
-    simde_memcpy(ptr, buf, sizeof(buf));
+    #if defined(SIMDE_RISCV_V_NATIVE) && SIMDE_ARCH_RISCV_ZVFH && (SIMDE_NATURAL_VECTOR_SIZE >= 128)
+      vfloat16m1x3_t dest = __riscv_vlseg3e16_v_f16m1x3((_Float16 *)ptr, 4);
+      dest = __riscv_vset_v_f16m1_f16m1x3 (dest, 0, a[0].sv64);
+      dest = __riscv_vset_v_f16m1_f16m1x3 (dest, 1, a[1].sv64);
+      dest = __riscv_vset_v_f16m1_f16m1x3 (dest, 2, a[2].sv64);
+      __riscv_vsseg3e16_v_f16m1x3 ((_Float16 *)ptr, dest, 4);
+    #else
+      simde_float16_t buf[12];
+      for (size_t i = 0; i < 12 ; i++) {
+        buf[i] = a[i % 3].values[i / 3];
+      }
+      simde_memcpy(ptr, buf, sizeof(buf));
+    #endif
   #endif
 }
 #if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
@@ -68,7 +77,13 @@ simde_vst3_f32(simde_float32_t ptr[HEDLEY_ARRAY_PARAM(6)], simde_float32x2x3_t v
     simde_float32x2_private a[3] = { simde_float32x2_to_private(val.val[0]),
                                       simde_float32x2_to_private(val.val[1]),
                                       simde_float32x2_to_private(val.val[2]) };
-    #if defined(SIMDE_SHUFFLE_VECTOR_)
+    #if defined(SIMDE_RISCV_V_NATIVE) && (SIMDE_NATURAL_VECTOR_SIZE >= 128)
+      vfloat32m1x3_t dest = __riscv_vlseg3e32_v_f32m1x3(ptr, 2);
+      dest = __riscv_vset_v_f32m1_f32m1x3 (dest, 0, a[0].sv64);
+      dest = __riscv_vset_v_f32m1_f32m1x3 (dest, 1, a[1].sv64);
+      dest = __riscv_vset_v_f32m1_f32m1x3 (dest, 2, a[2].sv64);
+      __riscv_vsseg3e32_v_f32m1x3 (ptr, dest, 2);
+    #elif defined(SIMDE_SHUFFLE_VECTOR_)
       __typeof__(a[0].values) r1 = SIMDE_SHUFFLE_VECTOR_(32, 8, a[0].values, a[1].values, 0, 2);
       __typeof__(a[0].values) r2 = SIMDE_SHUFFLE_VECTOR_(32, 8, a[2].values, a[0].values, 0, 3);
       __typeof__(a[0].values) r3 = SIMDE_SHUFFLE_VECTOR_(32, 8, a[1].values, a[2].values, 1, 3);
@@ -98,9 +113,17 @@ simde_vst3_f64(simde_float64_t ptr[HEDLEY_ARRAY_PARAM(3)], simde_float64x1x3_t v
     simde_float64x1_private a_[3] = { simde_float64x1_to_private(val.val[0]),
                                       simde_float64x1_to_private(val.val[1]),
                                       simde_float64x1_to_private(val.val[2]) };
-    simde_memcpy(ptr, &a_[0].values, sizeof(a_[0].values));
-    simde_memcpy(&ptr[1], &a_[1].values, sizeof(a_[1].values));
-    simde_memcpy(&ptr[2], &a_[2].values, sizeof(a_[2].values));
+    #if defined(SIMDE_RISCV_V_NATIVE) && (SIMDE_NATURAL_VECTOR_SIZE >= 128)
+      vfloat64m1x3_t dest = __riscv_vlseg3e64_v_f64m1x3(ptr, 1);
+      dest = __riscv_vset_v_f64m1_f64m1x3 (dest, 0, a_[0].sv64);
+      dest = __riscv_vset_v_f64m1_f64m1x3 (dest, 1, a_[1].sv64);
+      dest = __riscv_vset_v_f64m1_f64m1x3 (dest, 2, a_[2].sv64);
+      __riscv_vsseg3e64_v_f64m1x3(ptr, dest, 1);
+    #else
+      simde_memcpy(ptr, &a_[0].values, sizeof(a_[0].values));
+      simde_memcpy(&ptr[1], &a_[1].values, sizeof(a_[1].values));
+      simde_memcpy(&ptr[2], &a_[2].values, sizeof(a_[2].values));
+    #endif
   #endif
 }
 #if defined(SIMDE_ARM_NEON_A64V8_ENABLE_NATIVE_ALIASES)
@@ -117,7 +140,13 @@ simde_vst3_s8(int8_t ptr[HEDLEY_ARRAY_PARAM(24)], simde_int8x8x3_t val) {
     simde_int8x8_private a_[3] = { simde_int8x8_to_private(val.val[0]),
                                    simde_int8x8_to_private(val.val[1]),
                                    simde_int8x8_to_private(val.val[2]) };
-    #if defined(SIMDE_SHUFFLE_VECTOR_) && !defined(SIMDE_BUG_GCC_100762)
+    #if defined(SIMDE_RISCV_V_NATIVE) && (SIMDE_NATURAL_VECTOR_SIZE >= 128)
+      vint8m1x3_t dest = __riscv_vlseg3e8_v_i8m1x3(ptr, 8);
+      dest = __riscv_vset_v_i8m1_i8m1x3 (dest, 0, a_[0].sv64);
+      dest = __riscv_vset_v_i8m1_i8m1x3 (dest, 1, a_[1].sv64);
+      dest = __riscv_vset_v_i8m1_i8m1x3 (dest, 2, a_[2].sv64);
+      __riscv_vsseg3e8_v_i8m1x3(ptr, dest, 8);
+    #elif defined(SIMDE_SHUFFLE_VECTOR_) && !defined(SIMDE_BUG_GCC_100762)
       __typeof__(a_[0].values) r0 = SIMDE_SHUFFLE_VECTOR_(8, 8, a_[0].values, a_[1].values,
                                                           0, 8, 3, 1, 9, 4, 2, 10);
       __typeof__(a_[0].values) m0 = SIMDE_SHUFFLE_VECTOR_(8, 8, r0, a_[2].values,
@@ -158,7 +187,13 @@ simde_vst3_s16(int16_t ptr[HEDLEY_ARRAY_PARAM(12)], simde_int16x4x3_t val) {
     simde_int16x4_private a_[3] = { simde_int16x4_to_private(val.val[0]),
                                     simde_int16x4_to_private(val.val[1]),
                                     simde_int16x4_to_private(val.val[2]) };
-    #if defined(SIMDE_SHUFFLE_VECTOR_)
+    #if defined(SIMDE_RISCV_V_NATIVE) && (SIMDE_NATURAL_VECTOR_SIZE >= 128)
+      vint16m1x3_t dest = __riscv_vlseg3e16_v_i16m1x3(ptr, 4);
+      dest = __riscv_vset_v_i16m1_i16m1x3 (dest, 0, a_[0].sv64);
+      dest = __riscv_vset_v_i16m1_i16m1x3 (dest, 1, a_[1].sv64);
+      dest = __riscv_vset_v_i16m1_i16m1x3 (dest, 2, a_[2].sv64);
+      __riscv_vsseg3e16_v_i16m1x3 (ptr, dest, 4);
+    #elif defined(SIMDE_SHUFFLE_VECTOR_)
       __typeof__(a_[0].values) r0 = SIMDE_SHUFFLE_VECTOR_(16, 8, a_[0].values, a_[1].values,
                                                           0, 4, 1, 0);
       __typeof__(a_[0].values) m0 = SIMDE_SHUFFLE_VECTOR_(16, 8, r0, a_[2].values,
@@ -199,7 +234,13 @@ simde_vst3_s32(int32_t ptr[HEDLEY_ARRAY_PARAM(6)], simde_int32x2x3_t val) {
     simde_int32x2_private a[3] = { simde_int32x2_to_private(val.val[0]),
                                     simde_int32x2_to_private(val.val[1]),
                                     simde_int32x2_to_private(val.val[2]) };
-    #if defined(SIMDE_SHUFFLE_VECTOR_) && !defined(SIMDE_BUG_GCC_100762)
+    #if defined(SIMDE_RISCV_V_NATIVE) && (SIMDE_NATURAL_VECTOR_SIZE >= 128)
+      vint32m1x3_t dest = __riscv_vlseg3e32_v_i32m1x3(ptr, 2);
+      dest = __riscv_vset_v_i32m1_i32m1x3 (dest, 0, a[0].sv64);
+      dest = __riscv_vset_v_i32m1_i32m1x3 (dest, 1, a[1].sv64);
+      dest = __riscv_vset_v_i32m1_i32m1x3 (dest, 2, a[2].sv64);
+      __riscv_vsseg3e32_v_i32m1x3 (ptr, dest, 2);
+    #elif defined(SIMDE_SHUFFLE_VECTOR_) && !defined(SIMDE_BUG_GCC_100762)
       __typeof__(a[0].values) r1 = SIMDE_SHUFFLE_VECTOR_(32, 8, a[0].values, a[1].values, 0, 2);
       __typeof__(a[0].values) r2 = SIMDE_SHUFFLE_VECTOR_(32, 8, a[2].values, a[0].values, 0, 3);
       __typeof__(a[0].values) r3 = SIMDE_SHUFFLE_VECTOR_(32, 8, a[1].values, a[2].values, 1, 3);
@@ -229,9 +270,17 @@ simde_vst3_s64(int64_t ptr[HEDLEY_ARRAY_PARAM(3)], simde_int64x1x3_t val) {
     simde_int64x1_private a_[3] = { simde_int64x1_to_private(val.val[0]),
                                     simde_int64x1_to_private(val.val[1]),
                                     simde_int64x1_to_private(val.val[2]) };
-    simde_memcpy(ptr, &a_[0].values, sizeof(a_[0].values));
-    simde_memcpy(&ptr[1], &a_[1].values, sizeof(a_[1].values));
-    simde_memcpy(&ptr[2], &a_[2].values, sizeof(a_[2].values));
+    #if defined(SIMDE_RISCV_V_NATIVE) && (SIMDE_NATURAL_VECTOR_SIZE >= 128)
+      vint64m1x3_t dest = __riscv_vlseg3e64_v_i64m1x3(ptr, 1);
+      dest = __riscv_vset_v_i64m1_i64m1x3 (dest, 0, a_[0].sv64);
+      dest = __riscv_vset_v_i64m1_i64m1x3 (dest, 1, a_[1].sv64);
+      dest = __riscv_vset_v_i64m1_i64m1x3 (dest, 2, a_[2].sv64);
+      __riscv_vsseg3e64_v_i64m1x3 (ptr, dest, 1);
+    #else
+      simde_memcpy(ptr, &a_[0].values, sizeof(a_[0].values));
+      simde_memcpy(&ptr[1], &a_[1].values, sizeof(a_[1].values));
+      simde_memcpy(&ptr[2], &a_[2].values, sizeof(a_[2].values));
+    #endif
   #endif
 }
 #if defined(SIMDE_ARM_NEON_A64V8_ENABLE_NATIVE_ALIASES)
@@ -248,7 +297,13 @@ simde_vst3_u8(uint8_t ptr[HEDLEY_ARRAY_PARAM(24)], simde_uint8x8x3_t val) {
     simde_uint8x8_private a_[3] = { simde_uint8x8_to_private(val.val[0]),
                                     simde_uint8x8_to_private(val.val[1]),
                                     simde_uint8x8_to_private(val.val[2]) };
-    #if defined(SIMDE_SHUFFLE_VECTOR_) && !defined(SIMDE_BUG_GCC_100762)
+    #if defined(SIMDE_RISCV_V_NATIVE) && (SIMDE_NATURAL_VECTOR_SIZE >= 128)
+      vuint8m1x3_t dest = __riscv_vlseg3e8_v_u8m1x3(ptr, 8);
+      dest = __riscv_vset_v_u8m1_u8m1x3 (dest, 0, a_[0].sv64);
+      dest = __riscv_vset_v_u8m1_u8m1x3 (dest, 1, a_[1].sv64);
+      dest = __riscv_vset_v_u8m1_u8m1x3 (dest, 2, a_[2].sv64);
+      __riscv_vsseg3e8_v_u8m1x3 (ptr, dest, 8);
+    #elif defined(SIMDE_SHUFFLE_VECTOR_) && !defined(SIMDE_BUG_GCC_100762)
       __typeof__(a_[0].values) r0 = SIMDE_SHUFFLE_VECTOR_(8, 8, a_[0].values, a_[1].values,
                                                           0, 8, 3, 1, 9, 4, 2, 10);
       __typeof__(a_[0].values) m0 = SIMDE_SHUFFLE_VECTOR_(8, 8, r0, a_[2].values,
@@ -289,7 +344,13 @@ simde_vst3_u16(uint16_t ptr[HEDLEY_ARRAY_PARAM(12)], simde_uint16x4x3_t val) {
     simde_uint16x4_private a_[3] = { simde_uint16x4_to_private(val.val[0]),
                                      simde_uint16x4_to_private(val.val[1]),
                                      simde_uint16x4_to_private(val.val[2]) };
-    #if defined(SIMDE_SHUFFLE_VECTOR_)
+    #if defined(SIMDE_RISCV_V_NATIVE) && (SIMDE_NATURAL_VECTOR_SIZE >= 128)
+      vuint16m1x3_t dest = __riscv_vlseg3e16_v_u16m1x3(ptr, 4);
+      dest = __riscv_vset_v_u16m1_u16m1x3 (dest, 0, a_[0].sv64);
+      dest = __riscv_vset_v_u16m1_u16m1x3 (dest, 1, a_[1].sv64);
+      dest = __riscv_vset_v_u16m1_u16m1x3 (dest, 2, a_[2].sv64);
+      __riscv_vsseg3e16_v_u16m1x3 (ptr, dest, 4);
+    #elif defined(SIMDE_SHUFFLE_VECTOR_)
       __typeof__(a_[0].values) r0 = SIMDE_SHUFFLE_VECTOR_(16, 8, a_[0].values, a_[1].values,
                                                           0, 4, 1, 0);
       __typeof__(a_[0].values) m0 = SIMDE_SHUFFLE_VECTOR_(16, 8, r0, a_[2].values,
@@ -330,7 +391,13 @@ simde_vst3_u32(uint32_t ptr[HEDLEY_ARRAY_PARAM(6)], simde_uint32x2x3_t val) {
     simde_uint32x2_private a[3] = { simde_uint32x2_to_private(val.val[0]),
                                      simde_uint32x2_to_private(val.val[1]),
                                      simde_uint32x2_to_private(val.val[2]) };
-    #if defined(SIMDE_SHUFFLE_VECTOR_) && !defined(SIMDE_BUG_GCC_100762)
+    #if defined(SIMDE_RISCV_V_NATIVE) && (SIMDE_NATURAL_VECTOR_SIZE >= 128)
+      vuint32m1x3_t dest = __riscv_vlseg3e32_v_u32m1x3(ptr, 2);
+      dest = __riscv_vset_v_u32m1_u32m1x3 (dest, 0, a[0].sv64);
+      dest = __riscv_vset_v_u32m1_u32m1x3 (dest, 1, a[1].sv64);
+      dest = __riscv_vset_v_u32m1_u32m1x3 (dest, 2, a[2].sv64);
+      __riscv_vsseg3e32_v_u32m1x3 (ptr, dest, 2);
+    #elif defined(SIMDE_SHUFFLE_VECTOR_) && !defined(SIMDE_BUG_GCC_100762)
       __typeof__(a[0].values) r1 = SIMDE_SHUFFLE_VECTOR_(32, 8, a[0].values, a[1].values, 0, 2);
       __typeof__(a[0].values) r2 = SIMDE_SHUFFLE_VECTOR_(32, 8, a[2].values, a[0].values, 0, 3);
       __typeof__(a[0].values) r3 = SIMDE_SHUFFLE_VECTOR_(32, 8, a[1].values, a[2].values, 1, 3);
@@ -360,9 +427,17 @@ simde_vst3_u64(uint64_t ptr[HEDLEY_ARRAY_PARAM(3)], simde_uint64x1x3_t val) {
     simde_uint64x1_private a_[3] = { simde_uint64x1_to_private(val.val[0]),
                                      simde_uint64x1_to_private(val.val[1]),
                                      simde_uint64x1_to_private(val.val[2]) };
-    simde_memcpy(ptr, &a_[0].values, sizeof(a_[0].values));
-    simde_memcpy(&ptr[1], &a_[1].values, sizeof(a_[1].values));
-    simde_memcpy(&ptr[2], &a_[2].values, sizeof(a_[2].values));
+    #if defined(SIMDE_RISCV_V_NATIVE) && (SIMDE_NATURAL_VECTOR_SIZE >= 128)
+      vuint64m1x3_t dest = __riscv_vlseg3e64_v_u64m1x3(ptr, 1);
+      dest = __riscv_vset_v_u64m1_u64m1x3 (dest, 0, a_[0].sv64);
+      dest = __riscv_vset_v_u64m1_u64m1x3 (dest, 1, a_[1].sv64);
+      dest = __riscv_vset_v_u64m1_u64m1x3 (dest, 2, a_[2].sv64);
+      __riscv_vsseg3e64_v_u64m1x3 (ptr, dest, 1);
+    #else
+      simde_memcpy(ptr, &a_[0].values, sizeof(a_[0].values));
+      simde_memcpy(&ptr[1], &a_[1].values, sizeof(a_[1].values));
+      simde_memcpy(&ptr[2], &a_[2].values, sizeof(a_[2].values));
+    #endif
   #endif
 }
 #if defined(SIMDE_ARM_NEON_A64V8_ENABLE_NATIVE_ALIASES)
@@ -379,11 +454,19 @@ simde_vst3q_f16(simde_float16_t ptr[HEDLEY_ARRAY_PARAM(24)], simde_float16x8x3_t
     simde_float16x8_private a_[3] = { simde_float16x8_to_private(val.val[0]),
                                       simde_float16x8_to_private(val.val[1]),
                                       simde_float16x8_to_private(val.val[2]) };
-    simde_float16_t buf[24];
-    for (size_t i = 0; i < 24 ; i++) {
-      buf[i] = a_[i % 3].values[i / 3];
-    }
-    simde_memcpy(ptr, buf, sizeof(buf));
+    #if defined(SIMDE_RISCV_V_NATIVE) && SIMDE_ARCH_RISCV_ZVFH && (SIMDE_NATURAL_VECTOR_SIZE >= 128)
+      vfloat16m1x3_t dest = __riscv_vlseg3e16_v_f16m1x3((_Float16 *)ptr, 8);
+      dest = __riscv_vset_v_f16m1_f16m1x3 (dest, 0, a[0].sv128);
+      dest = __riscv_vset_v_f16m1_f16m1x3 (dest, 1, a[1].sv128);
+      dest = __riscv_vset_v_f16m1_f16m1x3 (dest, 2, a[2].sv128);
+      __riscv_vsseg3e16_v_f16m1x3 ((_Float16 *)ptr, dest, 8);
+    #else
+      simde_float16_t buf[24];
+      for (size_t i = 0; i < 24 ; i++) {
+        buf[i] = a_[i % 3].values[i / 3];
+      }
+      simde_memcpy(ptr, buf, sizeof(buf));
+    #endif
   #endif
 }
 #if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
@@ -400,7 +483,13 @@ simde_vst3q_f32(simde_float32_t ptr[HEDLEY_ARRAY_PARAM(12)], simde_float32x4x3_t
     simde_float32x4_private a_[3] = { simde_float32x4_to_private(val.val[0]),
                                       simde_float32x4_to_private(val.val[1]),
                                       simde_float32x4_to_private(val.val[2]) };
-    #if defined(SIMDE_SHUFFLE_VECTOR_)
+    #if defined(SIMDE_RISCV_V_NATIVE) && (SIMDE_NATURAL_VECTOR_SIZE >= 128)
+      vfloat32m1x3_t dest = __riscv_vlseg3e32_v_f32m1x3(ptr, 4);
+      dest = __riscv_vset_v_f32m1_f32m1x3 (dest, 0, a_[0].sv128);
+      dest = __riscv_vset_v_f32m1_f32m1x3 (dest, 1, a_[1].sv128);
+      dest = __riscv_vset_v_f32m1_f32m1x3 (dest, 2, a_[2].sv128);
+      __riscv_vsseg3e32_v_f32m1x3 (ptr, dest, 4);
+    #elif defined(SIMDE_SHUFFLE_VECTOR_)
       __typeof__(a_[0].values) r0 = SIMDE_SHUFFLE_VECTOR_(32, 16, a_[0].values, a_[1].values,
                                                           0, 4, 1, 0);
       __typeof__(a_[0].values) m0 = SIMDE_SHUFFLE_VECTOR_(32, 16, r0, a_[2].values,
@@ -441,7 +530,13 @@ simde_vst3q_f64(simde_float64_t ptr[HEDLEY_ARRAY_PARAM(6)], simde_float64x2x3_t 
     simde_float64x2_private a[3] = { simde_float64x2_to_private(val.val[0]),
                                       simde_float64x2_to_private(val.val[1]),
                                       simde_float64x2_to_private(val.val[2]) };
-    #if defined(SIMDE_SHUFFLE_VECTOR_)
+    #if defined(SIMDE_RISCV_V_NATIVE) && (SIMDE_NATURAL_VECTOR_SIZE >= 128)
+      vfloat64m1x3_t dest = __riscv_vlseg3e64_v_f64m1x3(ptr, 2);
+      dest = __riscv_vset_v_f64m1_f64m1x3 (dest, 0, a[0].sv128);
+      dest = __riscv_vset_v_f64m1_f64m1x3 (dest, 1, a[1].sv128);
+      dest = __riscv_vset_v_f64m1_f64m1x3 (dest, 2, a[2].sv128);
+      __riscv_vsseg3e64_v_f64m1x3 (ptr, dest, 2);
+    #elif defined(SIMDE_SHUFFLE_VECTOR_)
       __typeof__(a[0].values) r1 = SIMDE_SHUFFLE_VECTOR_(64, 16, a[0].values, a[1].values, 0, 2);
       __typeof__(a[0].values) r2 = SIMDE_SHUFFLE_VECTOR_(64, 16, a[2].values, a[0].values, 0, 3);
       __typeof__(a[0].values) r3 = SIMDE_SHUFFLE_VECTOR_(64, 16, a[1].values, a[2].values, 1, 3);
@@ -471,7 +566,13 @@ simde_vst3q_s8(int8_t ptr[HEDLEY_ARRAY_PARAM(48)], simde_int8x16x3_t val) {
     simde_int8x16_private a_[3] = { simde_int8x16_to_private(val.val[0]),
                                     simde_int8x16_to_private(val.val[1]),
                                     simde_int8x16_to_private(val.val[2]) };
-    #if defined(SIMDE_SHUFFLE_VECTOR_)
+    #if defined(SIMDE_RISCV_V_NATIVE) && (SIMDE_NATURAL_VECTOR_SIZE >= 128)
+      vint8m1x3_t dest = __riscv_vlseg3e8_v_i8m1x3(ptr, 16);
+      dest = __riscv_vset_v_i8m1_i8m1x3 (dest, 0, a_[0].sv128);
+      dest = __riscv_vset_v_i8m1_i8m1x3 (dest, 1, a_[1].sv128);
+      dest = __riscv_vset_v_i8m1_i8m1x3 (dest, 2, a_[2].sv128);
+      __riscv_vsseg3e8_v_i8m1x3 (ptr, dest, 16);
+    #elif defined(SIMDE_SHUFFLE_VECTOR_)
       __typeof__(a_[0].values) r0  = SIMDE_SHUFFLE_VECTOR_(8, 16, a_[0].values, a_[1].values,
                                                            0, 16, 6, 1, 17, 7, 2, 18, 8, 3, 19, 9,
                                                            4, 20, 10, 5);
@@ -517,7 +618,13 @@ simde_vst3q_s16(int16_t ptr[HEDLEY_ARRAY_PARAM(24)], simde_int16x8x3_t val) {
     simde_int16x8_private a_[3] = { simde_int16x8_to_private(val.val[0]),
                                     simde_int16x8_to_private(val.val[1]),
                                     simde_int16x8_to_private(val.val[2]) };
-    #if defined(SIMDE_SHUFFLE_VECTOR_)
+    #if defined(SIMDE_RISCV_V_NATIVE) && (SIMDE_NATURAL_VECTOR_SIZE >= 128)
+      vint16m1x3_t dest = __riscv_vlseg3e16_v_i16m1x3(ptr, 8);
+      dest = __riscv_vset_v_i16m1_i16m1x3 (dest, 0, a_[0].sv128);
+      dest = __riscv_vset_v_i16m1_i16m1x3 (dest, 1, a_[1].sv128);
+      dest = __riscv_vset_v_i16m1_i16m1x3 (dest, 2, a_[2].sv128);
+      __riscv_vsseg3e16_v_i16m1x3 (ptr, dest, 8);
+    #elif defined(SIMDE_SHUFFLE_VECTOR_)
       __typeof__(a_[0].values) r0 = SIMDE_SHUFFLE_VECTOR_(16, 16, a_[0].values, a_[1].values,
                                                           0, 8, 3, 1, 9, 4, 2, 10);
       __typeof__(a_[0].values) m0 = SIMDE_SHUFFLE_VECTOR_(16, 16, r0, a_[2].values,
@@ -558,7 +665,13 @@ simde_vst3q_s32(int32_t ptr[HEDLEY_ARRAY_PARAM(12)], simde_int32x4x3_t val) {
     simde_int32x4_private a_[3] = { simde_int32x4_to_private(val.val[0]),
                                     simde_int32x4_to_private(val.val[1]),
                                     simde_int32x4_to_private(val.val[2]) };
-    #if defined(SIMDE_SHUFFLE_VECTOR_)
+    #if defined(SIMDE_RISCV_V_NATIVE) && (SIMDE_NATURAL_VECTOR_SIZE >= 128)
+      vint32m1x3_t dest = __riscv_vlseg3e32_v_i32m1x3(ptr, 4);
+      dest = __riscv_vset_v_i32m1_i32m1x3 (dest, 0, a_[0].sv128);
+      dest = __riscv_vset_v_i32m1_i32m1x3 (dest, 1, a_[1].sv128);
+      dest = __riscv_vset_v_i32m1_i32m1x3 (dest, 2, a_[2].sv128);
+      __riscv_vsseg3e32_v_i32m1x3 (ptr, dest, 4);
+    #elif defined(SIMDE_SHUFFLE_VECTOR_)
       __typeof__(a_[0].values) r0 = SIMDE_SHUFFLE_VECTOR_(32, 16, a_[0].values, a_[1].values,
                                                           0, 4, 1, 0);
       __typeof__(a_[0].values) m0 = SIMDE_SHUFFLE_VECTOR_(32, 16, r0, a_[2].values,
@@ -599,7 +712,13 @@ simde_vst3q_s64(int64_t ptr[HEDLEY_ARRAY_PARAM(6)], simde_int64x2x3_t val) {
     simde_int64x2_private a[3] = { simde_int64x2_to_private(val.val[0]),
                                     simde_int64x2_to_private(val.val[1]),
                                     simde_int64x2_to_private(val.val[2]) };
-    #if defined(SIMDE_SHUFFLE_VECTOR_)
+    #if defined(SIMDE_RISCV_V_NATIVE) && (SIMDE_NATURAL_VECTOR_SIZE >= 128)
+      vint64m1x3_t dest = __riscv_vlseg3e64_v_i64m1x3(ptr, 2);
+      dest = __riscv_vset_v_i64m1_i64m1x3 (dest, 0, a[0].sv128);
+      dest = __riscv_vset_v_i64m1_i64m1x3 (dest, 1, a[1].sv128);
+      dest = __riscv_vset_v_i64m1_i64m1x3 (dest, 2, a[2].sv128);
+      __riscv_vsseg3e64_v_i64m1x3 (ptr, dest, 2);
+    #elif defined(SIMDE_SHUFFLE_VECTOR_)
       __typeof__(a[0].values) r1 = SIMDE_SHUFFLE_VECTOR_(64, 16, a[0].values, a[1].values, 0, 2);
       __typeof__(a[0].values) r2 = SIMDE_SHUFFLE_VECTOR_(64, 16, a[2].values, a[0].values, 0, 3);
       __typeof__(a[0].values) r3 = SIMDE_SHUFFLE_VECTOR_(64, 16, a[1].values, a[2].values, 1, 3);
@@ -661,6 +780,12 @@ simde_vst3q_u8(uint8_t ptr[HEDLEY_ARRAY_PARAM(48)], simde_uint8x16x3_t val) {
       v128_t m2 = wasm_i8x16_shuffle(r2, r1, 0, 1, 18, 3, 4, 21, 6, 7, 24, 9, 10,
                                      27, 12, 13, 30, 15);
       wasm_v128_store(ptr + 32, m2);
+    #elif defined(SIMDE_RISCV_V_NATIVE) && (SIMDE_NATURAL_VECTOR_SIZE >= 128)
+      vuint8m1x3_t dest = __riscv_vlseg3e8_v_u8m1x3(ptr, 16);
+      dest = __riscv_vset_v_u8m1_u8m1x3 (dest, 0, a_[0].sv128);
+      dest = __riscv_vset_v_u8m1_u8m1x3 (dest, 1, a_[1].sv128);
+      dest = __riscv_vset_v_u8m1_u8m1x3 (dest, 2, a_[2].sv128);
+      __riscv_vsseg3e8_v_u8m1x3 (ptr, dest, 16);
     #elif defined(SIMDE_SHUFFLE_VECTOR_)
       __typeof__(a_[0].values) r0  = SIMDE_SHUFFLE_VECTOR_(8, 16, a_[0].values, a_[1].values,
                                                            0, 16, 6, 1, 17, 7, 2, 18, 8, 3, 19, 9,
@@ -708,7 +833,13 @@ simde_vst3q_u16(uint16_t ptr[HEDLEY_ARRAY_PARAM(24)], simde_uint16x8x3_t val) {
                                      simde_uint16x8_to_private(val.val[1]),
                                      simde_uint16x8_to_private(val.val[2]) };
 
-    #if defined(SIMDE_SHUFFLE_VECTOR_)
+    #if defined(SIMDE_RISCV_V_NATIVE) && (SIMDE_NATURAL_VECTOR_SIZE >= 128)
+      vuint16m1x3_t dest = __riscv_vlseg3e16_v_u16m1x3(ptr, 8);
+      dest = __riscv_vset_v_u16m1_u16m1x3 (dest, 0, a_[0].sv128);
+      dest = __riscv_vset_v_u16m1_u16m1x3 (dest, 1, a_[1].sv128);
+      dest = __riscv_vset_v_u16m1_u16m1x3 (dest, 2, a_[2].sv128);
+      __riscv_vsseg3e16_v_u16m1x3 (ptr, dest, 8);
+    #elif defined(SIMDE_SHUFFLE_VECTOR_)
       __typeof__(a_[0].values) r0 = SIMDE_SHUFFLE_VECTOR_(16, 16, a_[0].values, a_[1].values,
                                                           0, 8, 3, 1, 9, 4, 2, 10);
       __typeof__(a_[0].values) m0 = SIMDE_SHUFFLE_VECTOR_(16, 16, r0, a_[2].values,
@@ -750,7 +881,13 @@ simde_vst3q_u32(uint32_t ptr[HEDLEY_ARRAY_PARAM(12)], simde_uint32x4x3_t val) {
                                      simde_uint32x4_to_private(val.val[1]),
                                      simde_uint32x4_to_private(val.val[2]) };
 
-    #if defined(SIMDE_SHUFFLE_VECTOR_)
+    #if defined(SIMDE_RISCV_V_NATIVE) && (SIMDE_NATURAL_VECTOR_SIZE >= 128)
+      vuint32m1x3_t dest = __riscv_vlseg3e32_v_u32m1x3(ptr, 4);
+      dest = __riscv_vset_v_u32m1_u32m1x3 (dest, 0, a_[0].sv128);
+      dest = __riscv_vset_v_u32m1_u32m1x3 (dest, 1, a_[1].sv128);
+      dest = __riscv_vset_v_u32m1_u32m1x3 (dest, 2, a_[2].sv128);
+      __riscv_vsseg3e32_v_u32m1x3 (ptr, dest, 4);
+    #elif defined(SIMDE_SHUFFLE_VECTOR_)
       __typeof__(a_[0].values) r0 = SIMDE_SHUFFLE_VECTOR_(32, 16, a_[0].values, a_[1].values,
                                                           0, 4, 1, 0);
       __typeof__(a_[0].values) m0 = SIMDE_SHUFFLE_VECTOR_(32, 16, r0, a_[2].values,
@@ -791,7 +928,13 @@ simde_vst3q_u64(uint64_t ptr[HEDLEY_ARRAY_PARAM(6)], simde_uint64x2x3_t val) {
     simde_uint64x2_private a[3] = { simde_uint64x2_to_private(val.val[0]),
                                      simde_uint64x2_to_private(val.val[1]),
                                      simde_uint64x2_to_private(val.val[2]) };
-    #if defined(SIMDE_SHUFFLE_VECTOR_)
+    #if defined(SIMDE_RISCV_V_NATIVE) && (SIMDE_NATURAL_VECTOR_SIZE >= 128)
+      vuint64m1x3_t dest = __riscv_vlseg3e64_v_u64m1x3(ptr, 2);
+      dest = __riscv_vset_v_u64m1_u64m1x3 (dest, 0, a[0].sv128);
+      dest = __riscv_vset_v_u64m1_u64m1x3 (dest, 1, a[1].sv128);
+      dest = __riscv_vset_v_u64m1_u64m1x3 (dest, 2, a[2].sv128);
+      __riscv_vsseg3e64_v_u64m1x3 (ptr, dest, 2);
+    #elif defined(SIMDE_SHUFFLE_VECTOR_)
       __typeof__(a[0].values) r1 = SIMDE_SHUFFLE_VECTOR_(64, 16, a[0].values, a[1].values, 0, 2);
       __typeof__(a[0].values) r2 = SIMDE_SHUFFLE_VECTOR_(64, 16, a[2].values, a[0].values, 0, 3);
       __typeof__(a[0].values) r3 = SIMDE_SHUFFLE_VECTOR_(64, 16, a[1].values, a[2].values, 1, 3);

--- a/simde/arm/neon/st3.h
+++ b/simde/arm/neon/st3.h
@@ -456,9 +456,9 @@ simde_vst3q_f16(simde_float16_t ptr[HEDLEY_ARRAY_PARAM(24)], simde_float16x8x3_t
                                       simde_float16x8_to_private(val.val[2]) };
     #if defined(SIMDE_RISCV_V_NATIVE) && SIMDE_ARCH_RISCV_ZVFH && (SIMDE_NATURAL_VECTOR_SIZE >= 128)
       vfloat16m1x3_t dest = __riscv_vlseg3e16_v_f16m1x3((_Float16 *)ptr, 8);
-      dest = __riscv_vset_v_f16m1_f16m1x3 (dest, 0, a[0].sv128);
-      dest = __riscv_vset_v_f16m1_f16m1x3 (dest, 1, a[1].sv128);
-      dest = __riscv_vset_v_f16m1_f16m1x3 (dest, 2, a[2].sv128);
+      dest = __riscv_vset_v_f16m1_f16m1x3 (dest, 0, a_[0].sv128);
+      dest = __riscv_vset_v_f16m1_f16m1x3 (dest, 1, a_[1].sv128);
+      dest = __riscv_vset_v_f16m1_f16m1x3 (dest, 2, a_[2].sv128);
       __riscv_vsseg3e16_v_f16m1x3 ((_Float16 *)ptr, dest, 8);
     #else
       simde_float16_t buf[24];

--- a/simde/arm/neon/st3.h
+++ b/simde/arm/neon/st3.h
@@ -77,7 +77,7 @@ simde_vst3_f32(simde_float32_t ptr[HEDLEY_ARRAY_PARAM(6)], simde_float32x2x3_t v
     simde_float32x2_private a[3] = { simde_float32x2_to_private(val.val[0]),
                                       simde_float32x2_to_private(val.val[1]),
                                       simde_float32x2_to_private(val.val[2]) };
-    #if defined(SIMDE_RISCV_V_NATIVE) && (SIMDE_NATURAL_VECTOR_SIZE >= 128)
+    #if defined(SIMDE_RISCV_V_NATIVE)
       vfloat32m1x3_t dest = __riscv_vlseg3e32_v_f32m1x3(ptr, 2);
       dest = __riscv_vset_v_f32m1_f32m1x3 (dest, 0, a[0].sv64);
       dest = __riscv_vset_v_f32m1_f32m1x3 (dest, 1, a[1].sv64);
@@ -113,7 +113,7 @@ simde_vst3_f64(simde_float64_t ptr[HEDLEY_ARRAY_PARAM(3)], simde_float64x1x3_t v
     simde_float64x1_private a_[3] = { simde_float64x1_to_private(val.val[0]),
                                       simde_float64x1_to_private(val.val[1]),
                                       simde_float64x1_to_private(val.val[2]) };
-    #if defined(SIMDE_RISCV_V_NATIVE) && (SIMDE_NATURAL_VECTOR_SIZE >= 128)
+    #if defined(SIMDE_RISCV_V_NATIVE)
       vfloat64m1x3_t dest = __riscv_vlseg3e64_v_f64m1x3(ptr, 1);
       dest = __riscv_vset_v_f64m1_f64m1x3 (dest, 0, a_[0].sv64);
       dest = __riscv_vset_v_f64m1_f64m1x3 (dest, 1, a_[1].sv64);
@@ -140,7 +140,7 @@ simde_vst3_s8(int8_t ptr[HEDLEY_ARRAY_PARAM(24)], simde_int8x8x3_t val) {
     simde_int8x8_private a_[3] = { simde_int8x8_to_private(val.val[0]),
                                    simde_int8x8_to_private(val.val[1]),
                                    simde_int8x8_to_private(val.val[2]) };
-    #if defined(SIMDE_RISCV_V_NATIVE) && (SIMDE_NATURAL_VECTOR_SIZE >= 128)
+    #if defined(SIMDE_RISCV_V_NATIVE)
       vint8m1x3_t dest = __riscv_vlseg3e8_v_i8m1x3(ptr, 8);
       dest = __riscv_vset_v_i8m1_i8m1x3 (dest, 0, a_[0].sv64);
       dest = __riscv_vset_v_i8m1_i8m1x3 (dest, 1, a_[1].sv64);
@@ -187,7 +187,7 @@ simde_vst3_s16(int16_t ptr[HEDLEY_ARRAY_PARAM(12)], simde_int16x4x3_t val) {
     simde_int16x4_private a_[3] = { simde_int16x4_to_private(val.val[0]),
                                     simde_int16x4_to_private(val.val[1]),
                                     simde_int16x4_to_private(val.val[2]) };
-    #if defined(SIMDE_RISCV_V_NATIVE) && (SIMDE_NATURAL_VECTOR_SIZE >= 128)
+    #if defined(SIMDE_RISCV_V_NATIVE)
       vint16m1x3_t dest = __riscv_vlseg3e16_v_i16m1x3(ptr, 4);
       dest = __riscv_vset_v_i16m1_i16m1x3 (dest, 0, a_[0].sv64);
       dest = __riscv_vset_v_i16m1_i16m1x3 (dest, 1, a_[1].sv64);
@@ -234,7 +234,7 @@ simde_vst3_s32(int32_t ptr[HEDLEY_ARRAY_PARAM(6)], simde_int32x2x3_t val) {
     simde_int32x2_private a[3] = { simde_int32x2_to_private(val.val[0]),
                                     simde_int32x2_to_private(val.val[1]),
                                     simde_int32x2_to_private(val.val[2]) };
-    #if defined(SIMDE_RISCV_V_NATIVE) && (SIMDE_NATURAL_VECTOR_SIZE >= 128)
+    #if defined(SIMDE_RISCV_V_NATIVE)
       vint32m1x3_t dest = __riscv_vlseg3e32_v_i32m1x3(ptr, 2);
       dest = __riscv_vset_v_i32m1_i32m1x3 (dest, 0, a[0].sv64);
       dest = __riscv_vset_v_i32m1_i32m1x3 (dest, 1, a[1].sv64);
@@ -270,7 +270,7 @@ simde_vst3_s64(int64_t ptr[HEDLEY_ARRAY_PARAM(3)], simde_int64x1x3_t val) {
     simde_int64x1_private a_[3] = { simde_int64x1_to_private(val.val[0]),
                                     simde_int64x1_to_private(val.val[1]),
                                     simde_int64x1_to_private(val.val[2]) };
-    #if defined(SIMDE_RISCV_V_NATIVE) && (SIMDE_NATURAL_VECTOR_SIZE >= 128)
+    #if defined(SIMDE_RISCV_V_NATIVE)
       vint64m1x3_t dest = __riscv_vlseg3e64_v_i64m1x3(ptr, 1);
       dest = __riscv_vset_v_i64m1_i64m1x3 (dest, 0, a_[0].sv64);
       dest = __riscv_vset_v_i64m1_i64m1x3 (dest, 1, a_[1].sv64);
@@ -297,7 +297,7 @@ simde_vst3_u8(uint8_t ptr[HEDLEY_ARRAY_PARAM(24)], simde_uint8x8x3_t val) {
     simde_uint8x8_private a_[3] = { simde_uint8x8_to_private(val.val[0]),
                                     simde_uint8x8_to_private(val.val[1]),
                                     simde_uint8x8_to_private(val.val[2]) };
-    #if defined(SIMDE_RISCV_V_NATIVE) && (SIMDE_NATURAL_VECTOR_SIZE >= 128)
+    #if defined(SIMDE_RISCV_V_NATIVE)
       vuint8m1x3_t dest = __riscv_vlseg3e8_v_u8m1x3(ptr, 8);
       dest = __riscv_vset_v_u8m1_u8m1x3 (dest, 0, a_[0].sv64);
       dest = __riscv_vset_v_u8m1_u8m1x3 (dest, 1, a_[1].sv64);
@@ -344,7 +344,7 @@ simde_vst3_u16(uint16_t ptr[HEDLEY_ARRAY_PARAM(12)], simde_uint16x4x3_t val) {
     simde_uint16x4_private a_[3] = { simde_uint16x4_to_private(val.val[0]),
                                      simde_uint16x4_to_private(val.val[1]),
                                      simde_uint16x4_to_private(val.val[2]) };
-    #if defined(SIMDE_RISCV_V_NATIVE) && (SIMDE_NATURAL_VECTOR_SIZE >= 128)
+    #if defined(SIMDE_RISCV_V_NATIVE)
       vuint16m1x3_t dest = __riscv_vlseg3e16_v_u16m1x3(ptr, 4);
       dest = __riscv_vset_v_u16m1_u16m1x3 (dest, 0, a_[0].sv64);
       dest = __riscv_vset_v_u16m1_u16m1x3 (dest, 1, a_[1].sv64);
@@ -391,7 +391,7 @@ simde_vst3_u32(uint32_t ptr[HEDLEY_ARRAY_PARAM(6)], simde_uint32x2x3_t val) {
     simde_uint32x2_private a[3] = { simde_uint32x2_to_private(val.val[0]),
                                      simde_uint32x2_to_private(val.val[1]),
                                      simde_uint32x2_to_private(val.val[2]) };
-    #if defined(SIMDE_RISCV_V_NATIVE) && (SIMDE_NATURAL_VECTOR_SIZE >= 128)
+    #if defined(SIMDE_RISCV_V_NATIVE)
       vuint32m1x3_t dest = __riscv_vlseg3e32_v_u32m1x3(ptr, 2);
       dest = __riscv_vset_v_u32m1_u32m1x3 (dest, 0, a[0].sv64);
       dest = __riscv_vset_v_u32m1_u32m1x3 (dest, 1, a[1].sv64);
@@ -427,7 +427,7 @@ simde_vst3_u64(uint64_t ptr[HEDLEY_ARRAY_PARAM(3)], simde_uint64x1x3_t val) {
     simde_uint64x1_private a_[3] = { simde_uint64x1_to_private(val.val[0]),
                                      simde_uint64x1_to_private(val.val[1]),
                                      simde_uint64x1_to_private(val.val[2]) };
-    #if defined(SIMDE_RISCV_V_NATIVE) && (SIMDE_NATURAL_VECTOR_SIZE >= 128)
+    #if defined(SIMDE_RISCV_V_NATIVE)
       vuint64m1x3_t dest = __riscv_vlseg3e64_v_u64m1x3(ptr, 1);
       dest = __riscv_vset_v_u64m1_u64m1x3 (dest, 0, a_[0].sv64);
       dest = __riscv_vset_v_u64m1_u64m1x3 (dest, 1, a_[1].sv64);
@@ -483,7 +483,7 @@ simde_vst3q_f32(simde_float32_t ptr[HEDLEY_ARRAY_PARAM(12)], simde_float32x4x3_t
     simde_float32x4_private a_[3] = { simde_float32x4_to_private(val.val[0]),
                                       simde_float32x4_to_private(val.val[1]),
                                       simde_float32x4_to_private(val.val[2]) };
-    #if defined(SIMDE_RISCV_V_NATIVE) && (SIMDE_NATURAL_VECTOR_SIZE >= 128)
+    #if defined(SIMDE_RISCV_V_NATIVE)
       vfloat32m1x3_t dest = __riscv_vlseg3e32_v_f32m1x3(ptr, 4);
       dest = __riscv_vset_v_f32m1_f32m1x3 (dest, 0, a_[0].sv128);
       dest = __riscv_vset_v_f32m1_f32m1x3 (dest, 1, a_[1].sv128);
@@ -530,7 +530,7 @@ simde_vst3q_f64(simde_float64_t ptr[HEDLEY_ARRAY_PARAM(6)], simde_float64x2x3_t 
     simde_float64x2_private a[3] = { simde_float64x2_to_private(val.val[0]),
                                       simde_float64x2_to_private(val.val[1]),
                                       simde_float64x2_to_private(val.val[2]) };
-    #if defined(SIMDE_RISCV_V_NATIVE) && (SIMDE_NATURAL_VECTOR_SIZE >= 128)
+    #if defined(SIMDE_RISCV_V_NATIVE)
       vfloat64m1x3_t dest = __riscv_vlseg3e64_v_f64m1x3(ptr, 2);
       dest = __riscv_vset_v_f64m1_f64m1x3 (dest, 0, a[0].sv128);
       dest = __riscv_vset_v_f64m1_f64m1x3 (dest, 1, a[1].sv128);
@@ -566,7 +566,7 @@ simde_vst3q_s8(int8_t ptr[HEDLEY_ARRAY_PARAM(48)], simde_int8x16x3_t val) {
     simde_int8x16_private a_[3] = { simde_int8x16_to_private(val.val[0]),
                                     simde_int8x16_to_private(val.val[1]),
                                     simde_int8x16_to_private(val.val[2]) };
-    #if defined(SIMDE_RISCV_V_NATIVE) && (SIMDE_NATURAL_VECTOR_SIZE >= 128)
+    #if defined(SIMDE_RISCV_V_NATIVE)
       vint8m1x3_t dest = __riscv_vlseg3e8_v_i8m1x3(ptr, 16);
       dest = __riscv_vset_v_i8m1_i8m1x3 (dest, 0, a_[0].sv128);
       dest = __riscv_vset_v_i8m1_i8m1x3 (dest, 1, a_[1].sv128);
@@ -618,7 +618,7 @@ simde_vst3q_s16(int16_t ptr[HEDLEY_ARRAY_PARAM(24)], simde_int16x8x3_t val) {
     simde_int16x8_private a_[3] = { simde_int16x8_to_private(val.val[0]),
                                     simde_int16x8_to_private(val.val[1]),
                                     simde_int16x8_to_private(val.val[2]) };
-    #if defined(SIMDE_RISCV_V_NATIVE) && (SIMDE_NATURAL_VECTOR_SIZE >= 128)
+    #if defined(SIMDE_RISCV_V_NATIVE)
       vint16m1x3_t dest = __riscv_vlseg3e16_v_i16m1x3(ptr, 8);
       dest = __riscv_vset_v_i16m1_i16m1x3 (dest, 0, a_[0].sv128);
       dest = __riscv_vset_v_i16m1_i16m1x3 (dest, 1, a_[1].sv128);
@@ -665,7 +665,7 @@ simde_vst3q_s32(int32_t ptr[HEDLEY_ARRAY_PARAM(12)], simde_int32x4x3_t val) {
     simde_int32x4_private a_[3] = { simde_int32x4_to_private(val.val[0]),
                                     simde_int32x4_to_private(val.val[1]),
                                     simde_int32x4_to_private(val.val[2]) };
-    #if defined(SIMDE_RISCV_V_NATIVE) && (SIMDE_NATURAL_VECTOR_SIZE >= 128)
+    #if defined(SIMDE_RISCV_V_NATIVE)
       vint32m1x3_t dest = __riscv_vlseg3e32_v_i32m1x3(ptr, 4);
       dest = __riscv_vset_v_i32m1_i32m1x3 (dest, 0, a_[0].sv128);
       dest = __riscv_vset_v_i32m1_i32m1x3 (dest, 1, a_[1].sv128);
@@ -712,7 +712,7 @@ simde_vst3q_s64(int64_t ptr[HEDLEY_ARRAY_PARAM(6)], simde_int64x2x3_t val) {
     simde_int64x2_private a[3] = { simde_int64x2_to_private(val.val[0]),
                                     simde_int64x2_to_private(val.val[1]),
                                     simde_int64x2_to_private(val.val[2]) };
-    #if defined(SIMDE_RISCV_V_NATIVE) && (SIMDE_NATURAL_VECTOR_SIZE >= 128)
+    #if defined(SIMDE_RISCV_V_NATIVE)
       vint64m1x3_t dest = __riscv_vlseg3e64_v_i64m1x3(ptr, 2);
       dest = __riscv_vset_v_i64m1_i64m1x3 (dest, 0, a[0].sv128);
       dest = __riscv_vset_v_i64m1_i64m1x3 (dest, 1, a[1].sv128);
@@ -780,7 +780,7 @@ simde_vst3q_u8(uint8_t ptr[HEDLEY_ARRAY_PARAM(48)], simde_uint8x16x3_t val) {
       v128_t m2 = wasm_i8x16_shuffle(r2, r1, 0, 1, 18, 3, 4, 21, 6, 7, 24, 9, 10,
                                      27, 12, 13, 30, 15);
       wasm_v128_store(ptr + 32, m2);
-    #elif defined(SIMDE_RISCV_V_NATIVE) && (SIMDE_NATURAL_VECTOR_SIZE >= 128)
+    #elif defined(SIMDE_RISCV_V_NATIVE)
       vuint8m1x3_t dest = __riscv_vlseg3e8_v_u8m1x3(ptr, 16);
       dest = __riscv_vset_v_u8m1_u8m1x3 (dest, 0, a_[0].sv128);
       dest = __riscv_vset_v_u8m1_u8m1x3 (dest, 1, a_[1].sv128);
@@ -833,7 +833,7 @@ simde_vst3q_u16(uint16_t ptr[HEDLEY_ARRAY_PARAM(24)], simde_uint16x8x3_t val) {
                                      simde_uint16x8_to_private(val.val[1]),
                                      simde_uint16x8_to_private(val.val[2]) };
 
-    #if defined(SIMDE_RISCV_V_NATIVE) && (SIMDE_NATURAL_VECTOR_SIZE >= 128)
+    #if defined(SIMDE_RISCV_V_NATIVE)
       vuint16m1x3_t dest = __riscv_vlseg3e16_v_u16m1x3(ptr, 8);
       dest = __riscv_vset_v_u16m1_u16m1x3 (dest, 0, a_[0].sv128);
       dest = __riscv_vset_v_u16m1_u16m1x3 (dest, 1, a_[1].sv128);
@@ -881,7 +881,7 @@ simde_vst3q_u32(uint32_t ptr[HEDLEY_ARRAY_PARAM(12)], simde_uint32x4x3_t val) {
                                      simde_uint32x4_to_private(val.val[1]),
                                      simde_uint32x4_to_private(val.val[2]) };
 
-    #if defined(SIMDE_RISCV_V_NATIVE) && (SIMDE_NATURAL_VECTOR_SIZE >= 128)
+    #if defined(SIMDE_RISCV_V_NATIVE)
       vuint32m1x3_t dest = __riscv_vlseg3e32_v_u32m1x3(ptr, 4);
       dest = __riscv_vset_v_u32m1_u32m1x3 (dest, 0, a_[0].sv128);
       dest = __riscv_vset_v_u32m1_u32m1x3 (dest, 1, a_[1].sv128);
@@ -928,7 +928,7 @@ simde_vst3q_u64(uint64_t ptr[HEDLEY_ARRAY_PARAM(6)], simde_uint64x2x3_t val) {
     simde_uint64x2_private a[3] = { simde_uint64x2_to_private(val.val[0]),
                                      simde_uint64x2_to_private(val.val[1]),
                                      simde_uint64x2_to_private(val.val[2]) };
-    #if defined(SIMDE_RISCV_V_NATIVE) && (SIMDE_NATURAL_VECTOR_SIZE >= 128)
+    #if defined(SIMDE_RISCV_V_NATIVE)
       vuint64m1x3_t dest = __riscv_vlseg3e64_v_u64m1x3(ptr, 2);
       dest = __riscv_vset_v_u64m1_u64m1x3 (dest, 0, a[0].sv128);
       dest = __riscv_vset_v_u64m1_u64m1x3 (dest, 1, a[1].sv128);

--- a/simde/arm/neon/st4.h
+++ b/simde/arm/neon/st4.h
@@ -24,6 +24,7 @@
  *   2020      Evan Nemerson <evan@nemerson.com>
  *   2020      Sean Maher <seanptmaher@gmail.com>
  *   2023      Yi-Yen Chung <eric681@andestech.com> (Copyright owned by Andes Technology)
+ *   2023      Chi-Wei Chu <wewe5215@gapp.nthu.edu.tw>
  */
 
 #if !defined(SIMDE_ARM_NEON_ST4_H)
@@ -43,13 +44,22 @@ simde_vst4_f16(simde_float16_t *ptr, simde_float16x4x4_t val) {
   #if defined(SIMDE_ARM_NEON_A32V7_NATIVE) && defined(SIMDE_ARM_NEON_FP16)
     vst4_f16(ptr, val);
   #else
-    simde_float16_t buf[16];
     simde_float16x4_private a_[4] = { simde_float16x4_to_private(val.val[0]), simde_float16x4_to_private(val.val[1]),
                                       simde_float16x4_to_private(val.val[2]), simde_float16x4_to_private(val.val[3]) };
-    for (size_t i = 0; i < 16 ; i++) {
-      buf[i] = a_[i % 4].values[i / 4];
-    }
-    simde_memcpy(ptr, buf, sizeof(buf));
+    #if defined(SIMDE_RISCV_V_NATIVE) && SIMDE_ARCH_RISCV_ZVFH && (SIMDE_NATURAL_VECTOR_SIZE >= 128)
+      vfloat16m1x4_t dest = __riscv_vlseg4e16_v_f16m1x4((_Float16 *)ptr, 4);
+      dest = __riscv_vset_v_f16m1_f16m1x4 (dest, 0, a_[0].sv64);
+      dest = __riscv_vset_v_f16m1_f16m1x4 (dest, 1, a_[1].sv64);
+      dest = __riscv_vset_v_f16m1_f16m1x4 (dest, 2, a_[2].sv64);
+      dest = __riscv_vset_v_f16m1_f16m1x4 (dest, 3, a_[3].sv64);
+      __riscv_vsseg4e16_v_f16m1x4 ((_Float16 *)ptr, dest, 4);
+    #else
+      simde_float16_t buf[16];
+      for (size_t i = 0; i < (sizeof(val.val[0]) / sizeof(*ptr)) * 4 ; i++) {
+        buf[i] = a_[i % 4].values[i / 4];
+      }
+      simde_memcpy(ptr, buf, sizeof(buf));
+    #endif
   #endif
 }
 #if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
@@ -63,13 +73,22 @@ simde_vst4_f32(simde_float32_t *ptr, simde_float32x2x4_t val) {
   #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
     vst4_f32(ptr, val);
   #else
-    simde_float32_t buf[8];
     simde_float32x2_private a_[4] = { simde_float32x2_to_private(val.val[0]), simde_float32x2_to_private(val.val[1]),
                                       simde_float32x2_to_private(val.val[2]), simde_float32x2_to_private(val.val[3]) };
-    for (size_t i = 0; i < 8 ; i++) {
-      buf[i] = a_[i % 4].values[i / 4];
-    }
-    simde_memcpy(ptr, buf, sizeof(buf));
+    #if defined(SIMDE_RISCV_V_NATIVE) && (SIMDE_NATURAL_VECTOR_SIZE >= 128)
+      vfloat32m1x4_t dest = __riscv_vlseg4e32_v_f32m1x4(ptr, 2);
+      dest = __riscv_vset_v_f32m1_f32m1x4 (dest, 0, a_[0].sv64);
+      dest = __riscv_vset_v_f32m1_f32m1x4 (dest, 1, a_[1].sv64);
+      dest = __riscv_vset_v_f32m1_f32m1x4 (dest, 2, a_[2].sv64);
+      dest = __riscv_vset_v_f32m1_f32m1x4 (dest, 3, a_[3].sv64);
+      __riscv_vsseg4e32_v_f32m1x4 (ptr, dest, 2);
+    #else
+      simde_float32_t buf[8];
+      for (size_t i = 0; i < (sizeof(val.val[0]) / sizeof(*ptr)) * 4 ; i++) {
+        buf[i] = a_[i % 4].values[i / 4];
+      }
+      simde_memcpy(ptr, buf, sizeof(buf));
+    #endif
   #endif
 }
 #if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
@@ -83,13 +102,22 @@ simde_vst4_f64(simde_float64_t *ptr, simde_float64x1x4_t val) {
   #if defined(SIMDE_ARM_NEON_A64V8_NATIVE)
     vst4_f64(ptr, val);
   #else
-    simde_float64_t buf[4];
     simde_float64x1_private a_[4] = { simde_float64x1_to_private(val.val[0]), simde_float64x1_to_private(val.val[1]),
                                       simde_float64x1_to_private(val.val[2]), simde_float64x1_to_private(val.val[3]) };
-    for (size_t i = 0; i < 4 ; i++) {
-      buf[i] = a_[i % 4].values[i / 4];
-    }
-    simde_memcpy(ptr, buf, sizeof(buf));
+    #if defined(SIMDE_RISCV_V_NATIVE) && (SIMDE_NATURAL_VECTOR_SIZE >= 128)
+      vfloat64m1x4_t dest = __riscv_vlseg4e64_v_f64m1x4(ptr, 1);
+      dest = __riscv_vset_v_f64m1_f64m1x4 (dest, 0, a_[0].sv64);
+      dest = __riscv_vset_v_f64m1_f64m1x4 (dest, 1, a_[1].sv64);
+      dest = __riscv_vset_v_f64m1_f64m1x4 (dest, 2, a_[2].sv64);
+      dest = __riscv_vset_v_f64m1_f64m1x4 (dest, 3, a_[3].sv64);
+      __riscv_vsseg4e64_v_f64m1x4(ptr, dest, 1);
+    #else
+      simde_float64_t buf[4];
+      for (size_t i = 0; i < (sizeof(val.val[0]) / sizeof(*ptr)) * 4 ; i++) {
+        buf[i] = a_[i % 4].values[i / 4];
+      }
+      simde_memcpy(ptr, buf, sizeof(buf));
+    #endif
   #endif
 }
 #if defined(SIMDE_ARM_NEON_A64V8_ENABLE_NATIVE_ALIASES)
@@ -103,13 +131,22 @@ simde_vst4_s8(int8_t *ptr, simde_int8x8x4_t val) {
   #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
     vst4_s8(ptr, val);
   #else
-    int8_t buf[32];
     simde_int8x8_private a_[4] = { simde_int8x8_to_private(val.val[0]), simde_int8x8_to_private(val.val[1]),
                                    simde_int8x8_to_private(val.val[2]), simde_int8x8_to_private(val.val[3]) };
-    for (size_t i = 0; i < 32 ; i++) {
-      buf[i] = a_[i % 4].values[i / 4];
-    }
-    simde_memcpy(ptr, buf, sizeof(buf));
+    #if defined(SIMDE_RISCV_V_NATIVE) && (SIMDE_NATURAL_VECTOR_SIZE >= 128)
+      vint8m1x4_t dest = __riscv_vlseg4e8_v_i8m1x4(ptr, 8);
+      dest = __riscv_vset_v_i8m1_i8m1x4 (dest, 0, a_[0].sv64);
+      dest = __riscv_vset_v_i8m1_i8m1x4 (dest, 1, a_[1].sv64);
+      dest = __riscv_vset_v_i8m1_i8m1x4 (dest, 2, a_[2].sv64);
+      dest = __riscv_vset_v_i8m1_i8m1x4 (dest, 3, a_[3].sv64);
+      __riscv_vsseg4e8_v_i8m1x4(ptr, dest, 8);
+    #else
+      int8_t buf[32];
+      for (size_t i = 0; i < (sizeof(val.val[0]) / sizeof(*ptr)) * 4 ; i++) {
+        buf[i] = a_[i % 4].values[i / 4];
+      }
+      simde_memcpy(ptr, buf, sizeof(buf));
+    #endif
   #endif
 }
 #if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
@@ -123,13 +160,22 @@ simde_vst4_s16(int16_t *ptr, simde_int16x4x4_t val) {
   #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
     vst4_s16(ptr, val);
   #else
-    int16_t buf[16];
     simde_int16x4_private a_[4] = { simde_int16x4_to_private(val.val[0]), simde_int16x4_to_private(val.val[1]),
                                     simde_int16x4_to_private(val.val[2]), simde_int16x4_to_private(val.val[3]) };
-    for (size_t i = 0; i < 16 ; i++) {
-      buf[i] = a_[i % 4].values[i / 4];
-    }
-    simde_memcpy(ptr, buf, sizeof(buf));
+    #if defined(SIMDE_RISCV_V_NATIVE) && (SIMDE_NATURAL_VECTOR_SIZE >= 128)
+      vint16m1x4_t dest = __riscv_vlseg4e16_v_i16m1x4(ptr, 4);
+      dest = __riscv_vset_v_i16m1_i16m1x4 (dest, 0, a_[0].sv64);
+      dest = __riscv_vset_v_i16m1_i16m1x4 (dest, 1, a_[1].sv64);
+      dest = __riscv_vset_v_i16m1_i16m1x4 (dest, 2, a_[2].sv64);
+      dest = __riscv_vset_v_i16m1_i16m1x4 (dest, 3, a_[3].sv64);
+      __riscv_vsseg4e16_v_i16m1x4 (ptr, dest, 4);
+    #else
+      int16_t buf[16];
+      for (size_t i = 0; i < (sizeof(val.val[0]) / sizeof(*ptr)) * 4 ; i++) {
+        buf[i] = a_[i % 4].values[i / 4];
+      }
+      simde_memcpy(ptr, buf, sizeof(buf));
+    #endif
   #endif
 }
 #if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
@@ -143,13 +189,22 @@ simde_vst4_s32(int32_t *ptr, simde_int32x2x4_t val) {
   #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
     vst4_s32(ptr, val);
   #else
-    int32_t buf[8];
     simde_int32x2_private a_[4] = { simde_int32x2_to_private(val.val[0]), simde_int32x2_to_private(val.val[1]),
                                     simde_int32x2_to_private(val.val[2]), simde_int32x2_to_private(val.val[3]) };
-    for (size_t i = 0; i < 8 ; i++) {
-      buf[i] = a_[i % 4].values[i / 4];
-    }
-    simde_memcpy(ptr, buf, sizeof(buf));
+    #if defined(SIMDE_RISCV_V_NATIVE) && (SIMDE_NATURAL_VECTOR_SIZE >= 128)
+      vint32m1x4_t dest = __riscv_vlseg4e32_v_i32m1x4(ptr, 2);
+      dest = __riscv_vset_v_i32m1_i32m1x4 (dest, 0, a_[0].sv64);
+      dest = __riscv_vset_v_i32m1_i32m1x4 (dest, 1, a_[1].sv64);
+      dest = __riscv_vset_v_i32m1_i32m1x4 (dest, 2, a_[2].sv64);
+      dest = __riscv_vset_v_i32m1_i32m1x4 (dest, 3, a_[3].sv64);
+      __riscv_vsseg4e32_v_i32m1x4 (ptr, dest, 2);
+    #else
+      int32_t buf[8];
+      for (size_t i = 0; i < (sizeof(val.val[0]) / sizeof(*ptr)) * 4 ; i++) {
+        buf[i] = a_[i % 4].values[i / 4];
+      }
+      simde_memcpy(ptr, buf, sizeof(buf));
+    #endif
   #endif
 }
 #if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
@@ -163,13 +218,22 @@ simde_vst4_s64(int64_t *ptr, simde_int64x1x4_t val) {
   #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
     vst4_s64(ptr, val);
   #else
-    int64_t buf[4];
     simde_int64x1_private a_[4] = { simde_int64x1_to_private(val.val[0]), simde_int64x1_to_private(val.val[1]),
                                     simde_int64x1_to_private(val.val[2]), simde_int64x1_to_private(val.val[3]) };
-    for (size_t i = 0; i < 4 ; i++) {
-      buf[i] = a_[i % 4].values[i / 4];
-    }
-    simde_memcpy(ptr, buf, sizeof(buf));
+    #if defined(SIMDE_RISCV_V_NATIVE) && (SIMDE_NATURAL_VECTOR_SIZE >= 128)
+      vint64m1x4_t dest = __riscv_vlseg4e64_v_i64m1x4(ptr, 1);
+      dest = __riscv_vset_v_i64m1_i64m1x4 (dest, 0, a_[0].sv64);
+      dest = __riscv_vset_v_i64m1_i64m1x4 (dest, 1, a_[1].sv64);
+      dest = __riscv_vset_v_i64m1_i64m1x4 (dest, 2, a_[2].sv64);
+      dest = __riscv_vset_v_i64m1_i64m1x4 (dest, 3, a_[3].sv64);
+      __riscv_vsseg4e64_v_i64m1x4 (ptr, dest, 1);
+    #else
+      int64_t buf[4];
+      for (size_t i = 0; i < (sizeof(val.val[0]) / sizeof(*ptr)) * 4 ; i++) {
+        buf[i] = a_[i % 4].values[i / 4];
+      }
+      simde_memcpy(ptr, buf, sizeof(buf));
+    #endif
   #endif
 }
 #if defined(SIMDE_ARM_NEON_A64V8_ENABLE_NATIVE_ALIASES)
@@ -183,13 +247,22 @@ simde_vst4_u8(uint8_t *ptr, simde_uint8x8x4_t val) {
   #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
     vst4_u8(ptr, val);
   #else
-    uint8_t buf[32];
     simde_uint8x8_private a_[4] = { simde_uint8x8_to_private(val.val[0]), simde_uint8x8_to_private(val.val[1]),
                                     simde_uint8x8_to_private(val.val[2]), simde_uint8x8_to_private(val.val[3]) };
-    for (size_t i = 0; i < 32 ; i++) {
-      buf[i] = a_[i % 4].values[i / 4];
-    }
-    simde_memcpy(ptr, buf, sizeof(buf));
+    #if defined(SIMDE_RISCV_V_NATIVE) && (SIMDE_NATURAL_VECTOR_SIZE >= 128)
+      vuint8m1x4_t dest = __riscv_vlseg4e8_v_u8m1x4(ptr, 8);
+      dest = __riscv_vset_v_u8m1_u8m1x4 (dest, 0, a_[0].sv64);
+      dest = __riscv_vset_v_u8m1_u8m1x4 (dest, 1, a_[1].sv64);
+      dest = __riscv_vset_v_u8m1_u8m1x4 (dest, 2, a_[2].sv64);
+      dest = __riscv_vset_v_u8m1_u8m1x4 (dest, 3, a_[3].sv64);
+      __riscv_vsseg4e8_v_u8m1x4 (ptr, dest, 8);
+    #else
+      uint8_t buf[32];
+      for (size_t i = 0; i < (sizeof(val.val[0]) / sizeof(*ptr)) * 4 ; i++) {
+        buf[i] = a_[i % 4].values[i / 4];
+      }
+      simde_memcpy(ptr, buf, sizeof(buf));
+    #endif
   #endif
 }
 #if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
@@ -203,13 +276,22 @@ simde_vst4_u16(uint16_t *ptr, simde_uint16x4x4_t val) {
   #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
     vst4_u16(ptr, val);
   #else
-    uint16_t buf[16];
     simde_uint16x4_private a_[4] = { simde_uint16x4_to_private(val.val[0]), simde_uint16x4_to_private(val.val[1]),
                                      simde_uint16x4_to_private(val.val[2]), simde_uint16x4_to_private(val.val[3]) };
-    for (size_t i = 0; i < 16 ; i++) {
-      buf[i] = a_[i % 4].values[i / 4];
-    }
-    simde_memcpy(ptr, buf, sizeof(buf));
+    #if defined(SIMDE_RISCV_V_NATIVE) && (SIMDE_NATURAL_VECTOR_SIZE >= 128)
+      vuint16m1x4_t dest = __riscv_vlseg4e16_v_u16m1x4(ptr, 4);
+      dest = __riscv_vset_v_u16m1_u16m1x4 (dest, 0, a_[0].sv64);
+      dest = __riscv_vset_v_u16m1_u16m1x4 (dest, 1, a_[1].sv64);
+      dest = __riscv_vset_v_u16m1_u16m1x4 (dest, 2, a_[2].sv64);
+      dest = __riscv_vset_v_u16m1_u16m1x4 (dest, 3, a_[3].sv64);
+      __riscv_vsseg4e16_v_u16m1x4 (ptr, dest, 4);
+    #else
+      uint16_t buf[16];
+      for (size_t i = 0; i < (sizeof(val.val[0]) / sizeof(*ptr)) * 4 ; i++) {
+        buf[i] = a_[i % 4].values[i / 4];
+      }
+      simde_memcpy(ptr, buf, sizeof(buf));
+    #endif
   #endif
 }
 #if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
@@ -223,13 +305,22 @@ simde_vst4_u32(uint32_t *ptr, simde_uint32x2x4_t val) {
   #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
     vst4_u32(ptr, val);
   #else
-    uint32_t buf[8];
     simde_uint32x2_private a_[4] = { simde_uint32x2_to_private(val.val[0]), simde_uint32x2_to_private(val.val[1]),
                                      simde_uint32x2_to_private(val.val[2]), simde_uint32x2_to_private(val.val[3]) };
-    for (size_t i = 0; i < 8 ; i++) {
-      buf[i] = a_[i % 4].values[i / 4];
-    }
-    simde_memcpy(ptr, buf, sizeof(buf));
+    #if defined(SIMDE_RISCV_V_NATIVE) && (SIMDE_NATURAL_VECTOR_SIZE >= 128)
+      vuint32m1x4_t dest = __riscv_vlseg4e32_v_u32m1x4(ptr, 2);
+      dest = __riscv_vset_v_u32m1_u32m1x4 (dest, 0, a_[0].sv64);
+      dest = __riscv_vset_v_u32m1_u32m1x4 (dest, 1, a_[1].sv64);
+      dest = __riscv_vset_v_u32m1_u32m1x4 (dest, 2, a_[2].sv64);
+      dest = __riscv_vset_v_u32m1_u32m1x4 (dest, 3, a_[3].sv64);
+      __riscv_vsseg4e32_v_u32m1x4 (ptr, dest, 2);
+    #else
+      uint32_t buf[8];
+      for (size_t i = 0; i < (sizeof(val.val[0]) / sizeof(*ptr)) * 4 ; i++) {
+        buf[i] = a_[i % 4].values[i / 4];
+      }
+      simde_memcpy(ptr, buf, sizeof(buf));
+    #endif
   #endif
 }
 #if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
@@ -243,13 +334,22 @@ simde_vst4_u64(uint64_t *ptr, simde_uint64x1x4_t val) {
   #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
     vst4_u64(ptr, val);
   #else
-    uint64_t buf[4];
     simde_uint64x1_private a_[4] = { simde_uint64x1_to_private(val.val[0]), simde_uint64x1_to_private(val.val[1]),
                                      simde_uint64x1_to_private(val.val[2]), simde_uint64x1_to_private(val.val[3]) };
-    for (size_t i = 0; i < 4 ; i++) {
-      buf[i] = a_[i % 4].values[i / 4];
-    }
-    simde_memcpy(ptr, buf, sizeof(buf));
+    #if defined(SIMDE_RISCV_V_NATIVE) && (SIMDE_NATURAL_VECTOR_SIZE >= 128)
+      vuint64m1x4_t dest = __riscv_vlseg4e64_v_u64m1x4(ptr, 1);
+      dest = __riscv_vset_v_u64m1_u64m1x4 (dest, 0, a_[0].sv64);
+      dest = __riscv_vset_v_u64m1_u64m1x4 (dest, 1, a_[1].sv64);
+      dest = __riscv_vset_v_u64m1_u64m1x4 (dest, 2, a_[2].sv64);
+      dest = __riscv_vset_v_u64m1_u64m1x4 (dest, 3, a_[3].sv64);
+      __riscv_vsseg4e64_v_u64m1x4 (ptr, dest, 1);
+    #else
+      uint64_t buf[4];
+      for (size_t i = 0; i < (sizeof(val.val[0]) / sizeof(*ptr)) * 4 ; i++) {
+        buf[i] = a_[i % 4].values[i / 4];
+      }
+      simde_memcpy(ptr, buf, sizeof(buf));
+    #endif
   #endif
 }
 #if defined(SIMDE_ARM_NEON_A64V8_ENABLE_NATIVE_ALIASES)
@@ -263,13 +363,22 @@ simde_vst4q_f16(simde_float16_t *ptr, simde_float16x8x4_t val) {
   #if defined(SIMDE_ARM_NEON_A32V7_NATIVE) && defined(SIMDE_ARM_NEON_FP16)
     vst4q_f16(ptr, val);
   #else
-    simde_float16_t buf[32];
     simde_float16x8_private a_[4] = { simde_float16x8_to_private(val.val[0]), simde_float16x8_to_private(val.val[1]),
                                       simde_float16x8_to_private(val.val[2]), simde_float16x8_to_private(val.val[3]) };
-    for (size_t i = 0; i < 32 ; i++) {
-      buf[i] = a_[i % 4].values[i / 4];
-    }
-    simde_memcpy(ptr, buf, sizeof(buf));
+    #if defined(SIMDE_RISCV_V_NATIVE) && SIMDE_ARCH_RISCV_ZVFH && (SIMDE_NATURAL_VECTOR_SIZE >= 128)
+      vfloat16m1x4_t dest = __riscv_vlseg4e16_v_f16m1x4((_Float16 *)ptr, 8);
+      dest = __riscv_vset_v_f16m1_f16m1x4 (dest, 0, a_[0].sv128);
+      dest = __riscv_vset_v_f16m1_f16m1x4 (dest, 1, a_[1].sv128);
+      dest = __riscv_vset_v_f16m1_f16m1x4 (dest, 2, a_[2].sv128);
+      dest = __riscv_vset_v_f16m1_f16m1x4 (dest, 3, a_[3].sv128);
+      __riscv_vsseg4e16_v_f16m1x4 ((_Float16 *)ptr, dest, 8);
+    #else
+      simde_float16_t buf[32];
+      for (size_t i = 0; i < (sizeof(val.val[0]) / sizeof(*ptr)) * 4 ; i++) {
+        buf[i] = a_[i % 4].values[i / 4];
+      }
+      simde_memcpy(ptr, buf, sizeof(buf));
+    #endif
   #endif
 }
 #if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
@@ -283,13 +392,22 @@ simde_vst4q_f32(simde_float32_t *ptr, simde_float32x4x4_t val) {
   #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
     vst4q_f32(ptr, val);
   #else
-    simde_float32_t buf[16];
     simde_float32x4_private a_[4] = { simde_float32x4_to_private(val.val[0]), simde_float32x4_to_private(val.val[1]),
                                       simde_float32x4_to_private(val.val[2]), simde_float32x4_to_private(val.val[3]) };
-    for (size_t i = 0; i < 16 ; i++) {
-      buf[i] = a_[i % 4].values[i / 4];
-    }
-    simde_memcpy(ptr, buf, sizeof(buf));
+    #if defined(SIMDE_RISCV_V_NATIVE) && (SIMDE_NATURAL_VECTOR_SIZE >= 128)
+      vfloat32m1x4_t dest = __riscv_vlseg4e32_v_f32m1x4(ptr, 4);
+      dest = __riscv_vset_v_f32m1_f32m1x4 (dest, 0, a_[0].sv128);
+      dest = __riscv_vset_v_f32m1_f32m1x4 (dest, 1, a_[1].sv128);
+      dest = __riscv_vset_v_f32m1_f32m1x4 (dest, 2, a_[2].sv128);
+      dest = __riscv_vset_v_f32m1_f32m1x4 (dest, 3, a_[3].sv128);
+      __riscv_vsseg4e32_v_f32m1x4 (ptr, dest, 4);
+    #else
+      simde_float32_t buf[16];
+      for (size_t i = 0; i < (sizeof(val.val[0]) / sizeof(*ptr)) * 4 ; i++) {
+        buf[i] = a_[i % 4].values[i / 4];
+      }
+      simde_memcpy(ptr, buf, sizeof(buf));
+    #endif
   #endif
 }
 #if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
@@ -303,13 +421,22 @@ simde_vst4q_f64(simde_float64_t *ptr, simde_float64x2x4_t val) {
   #if defined(SIMDE_ARM_NEON_A64V8_NATIVE)
     vst4q_f64(ptr, val);
   #else
-    simde_float64_t buf[8];
     simde_float64x2_private a_[4] = { simde_float64x2_to_private(val.val[0]), simde_float64x2_to_private(val.val[1]),
                                       simde_float64x2_to_private(val.val[2]), simde_float64x2_to_private(val.val[3]) };
-    for (size_t i = 0; i < 8 ; i++) {
-      buf[i] = a_[i % 4].values[i / 4];
-    }
-    simde_memcpy(ptr, buf, sizeof(buf));
+    #if defined(SIMDE_RISCV_V_NATIVE) && (SIMDE_NATURAL_VECTOR_SIZE >= 128)
+      vfloat64m1x4_t dest = __riscv_vlseg4e64_v_f64m1x4(ptr, 2);
+      dest = __riscv_vset_v_f64m1_f64m1x4 (dest, 0, a_[0].sv128);
+      dest = __riscv_vset_v_f64m1_f64m1x4 (dest, 1, a_[1].sv128);
+      dest = __riscv_vset_v_f64m1_f64m1x4 (dest, 2, a_[2].sv128);
+      dest = __riscv_vset_v_f64m1_f64m1x4 (dest, 3, a_[3].sv128);
+      __riscv_vsseg4e64_v_f64m1x4 (ptr, dest, 2);
+    #else
+      simde_float64_t buf[8];
+      for (size_t i = 0; i < (sizeof(val.val[0]) / sizeof(*ptr)) * 4 ; i++) {
+        buf[i] = a_[i % 4].values[i / 4];
+      }
+      simde_memcpy(ptr, buf, sizeof(buf));
+    #endif
   #endif
 }
 #if defined(SIMDE_ARM_NEON_A64V8_ENABLE_NATIVE_ALIASES)
@@ -323,13 +450,22 @@ simde_vst4q_s8(int8_t *ptr, simde_int8x16x4_t val) {
   #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
     vst4q_s8(ptr, val);
   #else
-    int8_t buf[64];
     simde_int8x16_private a_[4] = { simde_int8x16_to_private(val.val[0]), simde_int8x16_to_private(val.val[1]),
                                     simde_int8x16_to_private(val.val[2]), simde_int8x16_to_private(val.val[3]) };
-    for (size_t i = 0; i < 64 ; i++) {
-      buf[i] = a_[i % 4].values[i / 4];
-    }
-    simde_memcpy(ptr, buf, sizeof(buf));
+    #if defined(SIMDE_RISCV_V_NATIVE) && (SIMDE_NATURAL_VECTOR_SIZE >= 128)
+      vint8m1x4_t dest = __riscv_vlseg4e8_v_i8m1x4(ptr, 16);
+      dest = __riscv_vset_v_i8m1_i8m1x4 (dest, 0, a_[0].sv128);
+      dest = __riscv_vset_v_i8m1_i8m1x4 (dest, 1, a_[1].sv128);
+      dest = __riscv_vset_v_i8m1_i8m1x4 (dest, 2, a_[2].sv128);
+      dest = __riscv_vset_v_i8m1_i8m1x4 (dest, 3, a_[3].sv128);
+      __riscv_vsseg4e8_v_i8m1x4 (ptr, dest, 16);
+    #else
+      int8_t buf[64];
+      for (size_t i = 0; i < (sizeof(val.val[0]) / sizeof(*ptr)) * 4 ; i++) {
+        buf[i] = a_[i % 4].values[i / 4];
+      }
+      simde_memcpy(ptr, buf, sizeof(buf));
+    #endif
   #endif
 }
 #if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
@@ -343,13 +479,22 @@ simde_vst4q_s16(int16_t *ptr, simde_int16x8x4_t val) {
   #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
     vst4q_s16(ptr, val);
   #else
-    int16_t buf[32];
     simde_int16x8_private a_[4] = { simde_int16x8_to_private(val.val[0]), simde_int16x8_to_private(val.val[1]),
                                     simde_int16x8_to_private(val.val[2]), simde_int16x8_to_private(val.val[3]) };
-    for (size_t i = 0; i < 32 ; i++) {
-      buf[i] = a_[i % 4].values[i / 4];
-    }
-    simde_memcpy(ptr, buf, sizeof(buf));
+    #if defined(SIMDE_RISCV_V_NATIVE) && (SIMDE_NATURAL_VECTOR_SIZE >= 128)
+    vint16m1x4_t dest = __riscv_vlseg4e16_v_i16m1x4(ptr, 8);
+      dest = __riscv_vset_v_i16m1_i16m1x4 (dest, 0, a_[0].sv128);
+      dest = __riscv_vset_v_i16m1_i16m1x4 (dest, 1, a_[1].sv128);
+      dest = __riscv_vset_v_i16m1_i16m1x4 (dest, 2, a_[2].sv128);
+      dest = __riscv_vset_v_i16m1_i16m1x4 (dest, 3, a_[3].sv128);
+      __riscv_vsseg4e16_v_i16m1x4 (ptr, dest, 8);
+    #else
+      int16_t buf[32];
+      for (size_t i = 0; i < (sizeof(val.val[0]) / sizeof(*ptr)) * 4 ; i++) {
+        buf[i] = a_[i % 4].values[i / 4];
+      }
+      simde_memcpy(ptr, buf, sizeof(buf));
+    #endif
   #endif
 }
 #if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
@@ -363,13 +508,22 @@ simde_vst4q_s32(int32_t *ptr, simde_int32x4x4_t val) {
   #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
     vst4q_s32(ptr, val);
   #else
-    int32_t buf[16];
     simde_int32x4_private a_[4] = { simde_int32x4_to_private(val.val[0]), simde_int32x4_to_private(val.val[1]),
                                     simde_int32x4_to_private(val.val[2]), simde_int32x4_to_private(val.val[3]) };
-    for (size_t i = 0; i < 16 ; i++) {
-      buf[i] = a_[i % 4].values[i / 4];
-    }
-    simde_memcpy(ptr, buf, sizeof(buf));
+    #if defined(SIMDE_RISCV_V_NATIVE) && (SIMDE_NATURAL_VECTOR_SIZE >= 128)
+      vint32m1x4_t dest = __riscv_vlseg4e32_v_i32m1x4(ptr, 4);
+      dest = __riscv_vset_v_i32m1_i32m1x4 (dest, 0, a_[0].sv128);
+      dest = __riscv_vset_v_i32m1_i32m1x4 (dest, 1, a_[1].sv128);
+      dest = __riscv_vset_v_i32m1_i32m1x4 (dest, 2, a_[2].sv128);
+      dest = __riscv_vset_v_i32m1_i32m1x4 (dest, 3, a_[3].sv128);
+      __riscv_vsseg4e32_v_i32m1x4 (ptr, dest, 4);
+    #else
+      int32_t buf[16];
+      for (size_t i = 0; i < (sizeof(val.val[0]) / sizeof(*ptr)) * 4 ; i++) {
+        buf[i] = a_[i % 4].values[i / 4];
+      }
+      simde_memcpy(ptr, buf, sizeof(buf));
+    #endif
   #endif
 }
 #if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
@@ -383,13 +537,22 @@ simde_vst4q_s64(int64_t *ptr, simde_int64x2x4_t val) {
   #if defined(SIMDE_ARM_NEON_A64V8_NATIVE)
     vst4q_s64(ptr, val);
   #else
-    int64_t buf[8];
     simde_int64x2_private a_[4] = { simde_int64x2_to_private(val.val[0]), simde_int64x2_to_private(val.val[1]),
                                     simde_int64x2_to_private(val.val[2]), simde_int64x2_to_private(val.val[3]) };
-    for (size_t i = 0; i < 8 ; i++) {
-      buf[i] = a_[i % 4].values[i / 4];
-    }
-    simde_memcpy(ptr, buf, sizeof(buf));
+    #if defined(SIMDE_RISCV_V_NATIVE) && (SIMDE_NATURAL_VECTOR_SIZE >= 128)
+      vint64m1x4_t dest = __riscv_vlseg4e64_v_i64m1x4(ptr, 2);
+      dest = __riscv_vset_v_i64m1_i64m1x4 (dest, 0, a_[0].sv128);
+      dest = __riscv_vset_v_i64m1_i64m1x4 (dest, 1, a_[1].sv128);
+      dest = __riscv_vset_v_i64m1_i64m1x4 (dest, 2, a_[2].sv128);
+      dest = __riscv_vset_v_i64m1_i64m1x4 (dest, 3, a_[3].sv128);
+      __riscv_vsseg4e64_v_i64m1x4 (ptr, dest, 2);
+    #else
+      int64_t buf[8];
+      for (size_t i = 0; i < (sizeof(val.val[0]) / sizeof(*ptr)) * 4 ; i++) {
+        buf[i] = a_[i % 4].values[i / 4];
+      }
+      simde_memcpy(ptr, buf, sizeof(buf));
+    #endif
   #endif
 }
 #if defined(SIMDE_ARM_NEON_A64V8_ENABLE_NATIVE_ALIASES)
@@ -404,13 +567,22 @@ simde_vst4q_u8(uint8_t *ptr, simde_uint8x16x4_t val) {
   #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
     vst4q_u8(ptr, val);
   #else
-    uint8_t buf[64];
     simde_uint8x16_private a_[4] = { simde_uint8x16_to_private(val.val[0]), simde_uint8x16_to_private(val.val[1]),
                                      simde_uint8x16_to_private(val.val[2]), simde_uint8x16_to_private(val.val[3]) };
-    for (size_t i = 0; i < 64 ; i++) {
-      buf[i] = a_[i % 4].values[i / 4];
-    }
-    simde_memcpy(ptr, buf, sizeof(buf));
+    #if defined(SIMDE_RISCV_V_NATIVE) && (SIMDE_NATURAL_VECTOR_SIZE >= 128)
+      vuint8m1x4_t dest = __riscv_vlseg4e8_v_u8m1x4(ptr, 16);
+      dest = __riscv_vset_v_u8m1_u8m1x4 (dest, 0, a_[0].sv128);
+      dest = __riscv_vset_v_u8m1_u8m1x4 (dest, 1, a_[1].sv128);
+      dest = __riscv_vset_v_u8m1_u8m1x4 (dest, 2, a_[2].sv128);
+      dest = __riscv_vset_v_u8m1_u8m1x4 (dest, 3, a_[3].sv128);
+      __riscv_vsseg4e8_v_u8m1x4 (ptr, dest, 16);
+    #else
+      uint8_t buf[64];
+      for (size_t i = 0; i < (sizeof(val.val[0]) / sizeof(*ptr)) * 4 ; i++) {
+        buf[i] = a_[i % 4].values[i / 4];
+      }
+      simde_memcpy(ptr, buf, sizeof(buf));
+    #endif
   #endif
 }
 #if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
@@ -424,13 +596,22 @@ simde_vst4q_u16(uint16_t *ptr, simde_uint16x8x4_t val) {
   #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
     vst4q_u16(ptr, val);
   #else
-    uint16_t buf[32];
     simde_uint16x8_private a_[4] = { simde_uint16x8_to_private(val.val[0]), simde_uint16x8_to_private(val.val[1]),
                                      simde_uint16x8_to_private(val.val[2]), simde_uint16x8_to_private(val.val[3]) };
-    for (size_t i = 0; i < 32 ; i++) {
-      buf[i] = a_[i % 4].values[i / 4];
-    }
-    simde_memcpy(ptr, buf, sizeof(buf));
+    #if defined(SIMDE_RISCV_V_NATIVE) && (SIMDE_NATURAL_VECTOR_SIZE >= 128)
+      vuint16m1x4_t dest = __riscv_vlseg4e16_v_u16m1x4(ptr, 8);
+      dest = __riscv_vset_v_u16m1_u16m1x4 (dest, 0, a_[0].sv128);
+      dest = __riscv_vset_v_u16m1_u16m1x4 (dest, 1, a_[1].sv128);
+      dest = __riscv_vset_v_u16m1_u16m1x4 (dest, 2, a_[2].sv128);
+      dest = __riscv_vset_v_u16m1_u16m1x4 (dest, 3, a_[3].sv128);
+      __riscv_vsseg4e16_v_u16m1x4 (ptr, dest, 8);
+    #else
+      uint16_t buf[32];
+      for (size_t i = 0; i < (sizeof(val.val[0]) / sizeof(*ptr)) * 4 ; i++) {
+        buf[i] = a_[i % 4].values[i / 4];
+      }
+      simde_memcpy(ptr, buf, sizeof(buf));
+    #endif
   #endif
 }
 #if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
@@ -444,13 +625,22 @@ simde_vst4q_u32(uint32_t *ptr, simde_uint32x4x4_t val) {
   #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
     vst4q_u32(ptr, val);
   #else
-    uint32_t buf[16];
     simde_uint32x4_private a_[4] = { simde_uint32x4_to_private(val.val[0]), simde_uint32x4_to_private(val.val[1]),
                                      simde_uint32x4_to_private(val.val[2]), simde_uint32x4_to_private(val.val[3]) };
-    for (size_t i = 0; i < 16 ; i++) {
-      buf[i] = a_[i % 4].values[i / 4];
-    }
-    simde_memcpy(ptr, buf, sizeof(buf));
+    #if defined(SIMDE_RISCV_V_NATIVE) && (SIMDE_NATURAL_VECTOR_SIZE >= 128)
+      vuint32m1x4_t dest = __riscv_vlseg4e32_v_u32m1x4(ptr, 4);
+      dest = __riscv_vset_v_u32m1_u32m1x4 (dest, 0, a_[0].sv128);
+      dest = __riscv_vset_v_u32m1_u32m1x4 (dest, 1, a_[1].sv128);
+      dest = __riscv_vset_v_u32m1_u32m1x4 (dest, 2, a_[2].sv128);
+      dest = __riscv_vset_v_u32m1_u32m1x4 (dest, 3, a_[3].sv128);
+      __riscv_vsseg4e32_v_u32m1x4 (ptr, dest, 4);
+    #else
+      uint32_t buf[16];
+      for (size_t i = 0; i < (sizeof(val.val[0]) / sizeof(*ptr)) * 4 ; i++) {
+        buf[i] = a_[i % 4].values[i / 4];
+      }
+      simde_memcpy(ptr, buf, sizeof(buf));
+    #endif
   #endif
 }
 #if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
@@ -464,13 +654,22 @@ simde_vst4q_u64(uint64_t *ptr, simde_uint64x2x4_t val) {
   #if defined(SIMDE_ARM_NEON_A64V8_NATIVE)
     vst4q_u64(ptr, val);
   #else
-    uint64_t buf[8];
     simde_uint64x2_private a_[4] = { simde_uint64x2_to_private(val.val[0]), simde_uint64x2_to_private(val.val[1]),
                                      simde_uint64x2_to_private(val.val[2]), simde_uint64x2_to_private(val.val[3]) };
-    for (size_t i = 0; i < 8 ; i++) {
-      buf[i] = a_[i % 4].values[i / 4];
-    }
-    simde_memcpy(ptr, buf, sizeof(buf));
+    #if defined(SIMDE_RISCV_V_NATIVE) && (SIMDE_NATURAL_VECTOR_SIZE >= 128)
+      vuint64m1x4_t dest = __riscv_vlseg4e64_v_u64m1x4(ptr, 2);
+      dest = __riscv_vset_v_u64m1_u64m1x4 (dest, 0, a_[0].sv128);
+      dest = __riscv_vset_v_u64m1_u64m1x4 (dest, 1, a_[1].sv128);
+      dest = __riscv_vset_v_u64m1_u64m1x4 (dest, 2, a_[2].sv128);
+      dest = __riscv_vset_v_u64m1_u64m1x4 (dest, 3, a_[3].sv128);
+      __riscv_vsseg4e64_v_u64m1x4 (ptr, dest, 2);
+    #else
+      uint64_t buf[8];
+      for (size_t i = 0; i < (sizeof(val.val[0]) / sizeof(*ptr)) * 4 ; i++) {
+        buf[i] = a_[i % 4].values[i / 4];
+      }
+      simde_memcpy(ptr, buf, sizeof(buf));
+    #endif
   #endif
 }
 #if defined(SIMDE_ARM_NEON_A64V8_ENABLE_NATIVE_ALIASES)

--- a/simde/arm/neon/st4.h
+++ b/simde/arm/neon/st4.h
@@ -75,7 +75,7 @@ simde_vst4_f32(simde_float32_t *ptr, simde_float32x2x4_t val) {
   #else
     simde_float32x2_private a_[4] = { simde_float32x2_to_private(val.val[0]), simde_float32x2_to_private(val.val[1]),
                                       simde_float32x2_to_private(val.val[2]), simde_float32x2_to_private(val.val[3]) };
-    #if defined(SIMDE_RISCV_V_NATIVE) && (SIMDE_NATURAL_VECTOR_SIZE >= 128)
+    #if defined(SIMDE_RISCV_V_NATIVE)
       vfloat32m1x4_t dest = __riscv_vlseg4e32_v_f32m1x4(ptr, 2);
       dest = __riscv_vset_v_f32m1_f32m1x4 (dest, 0, a_[0].sv64);
       dest = __riscv_vset_v_f32m1_f32m1x4 (dest, 1, a_[1].sv64);
@@ -104,7 +104,7 @@ simde_vst4_f64(simde_float64_t *ptr, simde_float64x1x4_t val) {
   #else
     simde_float64x1_private a_[4] = { simde_float64x1_to_private(val.val[0]), simde_float64x1_to_private(val.val[1]),
                                       simde_float64x1_to_private(val.val[2]), simde_float64x1_to_private(val.val[3]) };
-    #if defined(SIMDE_RISCV_V_NATIVE) && (SIMDE_NATURAL_VECTOR_SIZE >= 128)
+    #if defined(SIMDE_RISCV_V_NATIVE)
       vfloat64m1x4_t dest = __riscv_vlseg4e64_v_f64m1x4(ptr, 1);
       dest = __riscv_vset_v_f64m1_f64m1x4 (dest, 0, a_[0].sv64);
       dest = __riscv_vset_v_f64m1_f64m1x4 (dest, 1, a_[1].sv64);
@@ -133,7 +133,7 @@ simde_vst4_s8(int8_t *ptr, simde_int8x8x4_t val) {
   #else
     simde_int8x8_private a_[4] = { simde_int8x8_to_private(val.val[0]), simde_int8x8_to_private(val.val[1]),
                                    simde_int8x8_to_private(val.val[2]), simde_int8x8_to_private(val.val[3]) };
-    #if defined(SIMDE_RISCV_V_NATIVE) && (SIMDE_NATURAL_VECTOR_SIZE >= 128)
+    #if defined(SIMDE_RISCV_V_NATIVE)
       vint8m1x4_t dest = __riscv_vlseg4e8_v_i8m1x4(ptr, 8);
       dest = __riscv_vset_v_i8m1_i8m1x4 (dest, 0, a_[0].sv64);
       dest = __riscv_vset_v_i8m1_i8m1x4 (dest, 1, a_[1].sv64);
@@ -162,7 +162,7 @@ simde_vst4_s16(int16_t *ptr, simde_int16x4x4_t val) {
   #else
     simde_int16x4_private a_[4] = { simde_int16x4_to_private(val.val[0]), simde_int16x4_to_private(val.val[1]),
                                     simde_int16x4_to_private(val.val[2]), simde_int16x4_to_private(val.val[3]) };
-    #if defined(SIMDE_RISCV_V_NATIVE) && (SIMDE_NATURAL_VECTOR_SIZE >= 128)
+    #if defined(SIMDE_RISCV_V_NATIVE)
       vint16m1x4_t dest = __riscv_vlseg4e16_v_i16m1x4(ptr, 4);
       dest = __riscv_vset_v_i16m1_i16m1x4 (dest, 0, a_[0].sv64);
       dest = __riscv_vset_v_i16m1_i16m1x4 (dest, 1, a_[1].sv64);
@@ -191,7 +191,7 @@ simde_vst4_s32(int32_t *ptr, simde_int32x2x4_t val) {
   #else
     simde_int32x2_private a_[4] = { simde_int32x2_to_private(val.val[0]), simde_int32x2_to_private(val.val[1]),
                                     simde_int32x2_to_private(val.val[2]), simde_int32x2_to_private(val.val[3]) };
-    #if defined(SIMDE_RISCV_V_NATIVE) && (SIMDE_NATURAL_VECTOR_SIZE >= 128)
+    #if defined(SIMDE_RISCV_V_NATIVE)
       vint32m1x4_t dest = __riscv_vlseg4e32_v_i32m1x4(ptr, 2);
       dest = __riscv_vset_v_i32m1_i32m1x4 (dest, 0, a_[0].sv64);
       dest = __riscv_vset_v_i32m1_i32m1x4 (dest, 1, a_[1].sv64);
@@ -220,7 +220,7 @@ simde_vst4_s64(int64_t *ptr, simde_int64x1x4_t val) {
   #else
     simde_int64x1_private a_[4] = { simde_int64x1_to_private(val.val[0]), simde_int64x1_to_private(val.val[1]),
                                     simde_int64x1_to_private(val.val[2]), simde_int64x1_to_private(val.val[3]) };
-    #if defined(SIMDE_RISCV_V_NATIVE) && (SIMDE_NATURAL_VECTOR_SIZE >= 128)
+    #if defined(SIMDE_RISCV_V_NATIVE)
       vint64m1x4_t dest = __riscv_vlseg4e64_v_i64m1x4(ptr, 1);
       dest = __riscv_vset_v_i64m1_i64m1x4 (dest, 0, a_[0].sv64);
       dest = __riscv_vset_v_i64m1_i64m1x4 (dest, 1, a_[1].sv64);
@@ -249,7 +249,7 @@ simde_vst4_u8(uint8_t *ptr, simde_uint8x8x4_t val) {
   #else
     simde_uint8x8_private a_[4] = { simde_uint8x8_to_private(val.val[0]), simde_uint8x8_to_private(val.val[1]),
                                     simde_uint8x8_to_private(val.val[2]), simde_uint8x8_to_private(val.val[3]) };
-    #if defined(SIMDE_RISCV_V_NATIVE) && (SIMDE_NATURAL_VECTOR_SIZE >= 128)
+    #if defined(SIMDE_RISCV_V_NATIVE)
       vuint8m1x4_t dest = __riscv_vlseg4e8_v_u8m1x4(ptr, 8);
       dest = __riscv_vset_v_u8m1_u8m1x4 (dest, 0, a_[0].sv64);
       dest = __riscv_vset_v_u8m1_u8m1x4 (dest, 1, a_[1].sv64);
@@ -278,7 +278,7 @@ simde_vst4_u16(uint16_t *ptr, simde_uint16x4x4_t val) {
   #else
     simde_uint16x4_private a_[4] = { simde_uint16x4_to_private(val.val[0]), simde_uint16x4_to_private(val.val[1]),
                                      simde_uint16x4_to_private(val.val[2]), simde_uint16x4_to_private(val.val[3]) };
-    #if defined(SIMDE_RISCV_V_NATIVE) && (SIMDE_NATURAL_VECTOR_SIZE >= 128)
+    #if defined(SIMDE_RISCV_V_NATIVE)
       vuint16m1x4_t dest = __riscv_vlseg4e16_v_u16m1x4(ptr, 4);
       dest = __riscv_vset_v_u16m1_u16m1x4 (dest, 0, a_[0].sv64);
       dest = __riscv_vset_v_u16m1_u16m1x4 (dest, 1, a_[1].sv64);
@@ -307,7 +307,7 @@ simde_vst4_u32(uint32_t *ptr, simde_uint32x2x4_t val) {
   #else
     simde_uint32x2_private a_[4] = { simde_uint32x2_to_private(val.val[0]), simde_uint32x2_to_private(val.val[1]),
                                      simde_uint32x2_to_private(val.val[2]), simde_uint32x2_to_private(val.val[3]) };
-    #if defined(SIMDE_RISCV_V_NATIVE) && (SIMDE_NATURAL_VECTOR_SIZE >= 128)
+    #if defined(SIMDE_RISCV_V_NATIVE)
       vuint32m1x4_t dest = __riscv_vlseg4e32_v_u32m1x4(ptr, 2);
       dest = __riscv_vset_v_u32m1_u32m1x4 (dest, 0, a_[0].sv64);
       dest = __riscv_vset_v_u32m1_u32m1x4 (dest, 1, a_[1].sv64);
@@ -336,7 +336,7 @@ simde_vst4_u64(uint64_t *ptr, simde_uint64x1x4_t val) {
   #else
     simde_uint64x1_private a_[4] = { simde_uint64x1_to_private(val.val[0]), simde_uint64x1_to_private(val.val[1]),
                                      simde_uint64x1_to_private(val.val[2]), simde_uint64x1_to_private(val.val[3]) };
-    #if defined(SIMDE_RISCV_V_NATIVE) && (SIMDE_NATURAL_VECTOR_SIZE >= 128)
+    #if defined(SIMDE_RISCV_V_NATIVE)
       vuint64m1x4_t dest = __riscv_vlseg4e64_v_u64m1x4(ptr, 1);
       dest = __riscv_vset_v_u64m1_u64m1x4 (dest, 0, a_[0].sv64);
       dest = __riscv_vset_v_u64m1_u64m1x4 (dest, 1, a_[1].sv64);
@@ -394,7 +394,7 @@ simde_vst4q_f32(simde_float32_t *ptr, simde_float32x4x4_t val) {
   #else
     simde_float32x4_private a_[4] = { simde_float32x4_to_private(val.val[0]), simde_float32x4_to_private(val.val[1]),
                                       simde_float32x4_to_private(val.val[2]), simde_float32x4_to_private(val.val[3]) };
-    #if defined(SIMDE_RISCV_V_NATIVE) && (SIMDE_NATURAL_VECTOR_SIZE >= 128)
+    #if defined(SIMDE_RISCV_V_NATIVE)
       vfloat32m1x4_t dest = __riscv_vlseg4e32_v_f32m1x4(ptr, 4);
       dest = __riscv_vset_v_f32m1_f32m1x4 (dest, 0, a_[0].sv128);
       dest = __riscv_vset_v_f32m1_f32m1x4 (dest, 1, a_[1].sv128);
@@ -423,7 +423,7 @@ simde_vst4q_f64(simde_float64_t *ptr, simde_float64x2x4_t val) {
   #else
     simde_float64x2_private a_[4] = { simde_float64x2_to_private(val.val[0]), simde_float64x2_to_private(val.val[1]),
                                       simde_float64x2_to_private(val.val[2]), simde_float64x2_to_private(val.val[3]) };
-    #if defined(SIMDE_RISCV_V_NATIVE) && (SIMDE_NATURAL_VECTOR_SIZE >= 128)
+    #if defined(SIMDE_RISCV_V_NATIVE)
       vfloat64m1x4_t dest = __riscv_vlseg4e64_v_f64m1x4(ptr, 2);
       dest = __riscv_vset_v_f64m1_f64m1x4 (dest, 0, a_[0].sv128);
       dest = __riscv_vset_v_f64m1_f64m1x4 (dest, 1, a_[1].sv128);
@@ -452,7 +452,7 @@ simde_vst4q_s8(int8_t *ptr, simde_int8x16x4_t val) {
   #else
     simde_int8x16_private a_[4] = { simde_int8x16_to_private(val.val[0]), simde_int8x16_to_private(val.val[1]),
                                     simde_int8x16_to_private(val.val[2]), simde_int8x16_to_private(val.val[3]) };
-    #if defined(SIMDE_RISCV_V_NATIVE) && (SIMDE_NATURAL_VECTOR_SIZE >= 128)
+    #if defined(SIMDE_RISCV_V_NATIVE)
       vint8m1x4_t dest = __riscv_vlseg4e8_v_i8m1x4(ptr, 16);
       dest = __riscv_vset_v_i8m1_i8m1x4 (dest, 0, a_[0].sv128);
       dest = __riscv_vset_v_i8m1_i8m1x4 (dest, 1, a_[1].sv128);
@@ -481,7 +481,7 @@ simde_vst4q_s16(int16_t *ptr, simde_int16x8x4_t val) {
   #else
     simde_int16x8_private a_[4] = { simde_int16x8_to_private(val.val[0]), simde_int16x8_to_private(val.val[1]),
                                     simde_int16x8_to_private(val.val[2]), simde_int16x8_to_private(val.val[3]) };
-    #if defined(SIMDE_RISCV_V_NATIVE) && (SIMDE_NATURAL_VECTOR_SIZE >= 128)
+    #if defined(SIMDE_RISCV_V_NATIVE)
     vint16m1x4_t dest = __riscv_vlseg4e16_v_i16m1x4(ptr, 8);
       dest = __riscv_vset_v_i16m1_i16m1x4 (dest, 0, a_[0].sv128);
       dest = __riscv_vset_v_i16m1_i16m1x4 (dest, 1, a_[1].sv128);
@@ -510,7 +510,7 @@ simde_vst4q_s32(int32_t *ptr, simde_int32x4x4_t val) {
   #else
     simde_int32x4_private a_[4] = { simde_int32x4_to_private(val.val[0]), simde_int32x4_to_private(val.val[1]),
                                     simde_int32x4_to_private(val.val[2]), simde_int32x4_to_private(val.val[3]) };
-    #if defined(SIMDE_RISCV_V_NATIVE) && (SIMDE_NATURAL_VECTOR_SIZE >= 128)
+    #if defined(SIMDE_RISCV_V_NATIVE)
       vint32m1x4_t dest = __riscv_vlseg4e32_v_i32m1x4(ptr, 4);
       dest = __riscv_vset_v_i32m1_i32m1x4 (dest, 0, a_[0].sv128);
       dest = __riscv_vset_v_i32m1_i32m1x4 (dest, 1, a_[1].sv128);
@@ -539,7 +539,7 @@ simde_vst4q_s64(int64_t *ptr, simde_int64x2x4_t val) {
   #else
     simde_int64x2_private a_[4] = { simde_int64x2_to_private(val.val[0]), simde_int64x2_to_private(val.val[1]),
                                     simde_int64x2_to_private(val.val[2]), simde_int64x2_to_private(val.val[3]) };
-    #if defined(SIMDE_RISCV_V_NATIVE) && (SIMDE_NATURAL_VECTOR_SIZE >= 128)
+    #if defined(SIMDE_RISCV_V_NATIVE)
       vint64m1x4_t dest = __riscv_vlseg4e64_v_i64m1x4(ptr, 2);
       dest = __riscv_vset_v_i64m1_i64m1x4 (dest, 0, a_[0].sv128);
       dest = __riscv_vset_v_i64m1_i64m1x4 (dest, 1, a_[1].sv128);
@@ -569,7 +569,7 @@ simde_vst4q_u8(uint8_t *ptr, simde_uint8x16x4_t val) {
   #else
     simde_uint8x16_private a_[4] = { simde_uint8x16_to_private(val.val[0]), simde_uint8x16_to_private(val.val[1]),
                                      simde_uint8x16_to_private(val.val[2]), simde_uint8x16_to_private(val.val[3]) };
-    #if defined(SIMDE_RISCV_V_NATIVE) && (SIMDE_NATURAL_VECTOR_SIZE >= 128)
+    #if defined(SIMDE_RISCV_V_NATIVE)
       vuint8m1x4_t dest = __riscv_vlseg4e8_v_u8m1x4(ptr, 16);
       dest = __riscv_vset_v_u8m1_u8m1x4 (dest, 0, a_[0].sv128);
       dest = __riscv_vset_v_u8m1_u8m1x4 (dest, 1, a_[1].sv128);
@@ -598,7 +598,7 @@ simde_vst4q_u16(uint16_t *ptr, simde_uint16x8x4_t val) {
   #else
     simde_uint16x8_private a_[4] = { simde_uint16x8_to_private(val.val[0]), simde_uint16x8_to_private(val.val[1]),
                                      simde_uint16x8_to_private(val.val[2]), simde_uint16x8_to_private(val.val[3]) };
-    #if defined(SIMDE_RISCV_V_NATIVE) && (SIMDE_NATURAL_VECTOR_SIZE >= 128)
+    #if defined(SIMDE_RISCV_V_NATIVE)
       vuint16m1x4_t dest = __riscv_vlseg4e16_v_u16m1x4(ptr, 8);
       dest = __riscv_vset_v_u16m1_u16m1x4 (dest, 0, a_[0].sv128);
       dest = __riscv_vset_v_u16m1_u16m1x4 (dest, 1, a_[1].sv128);
@@ -627,7 +627,7 @@ simde_vst4q_u32(uint32_t *ptr, simde_uint32x4x4_t val) {
   #else
     simde_uint32x4_private a_[4] = { simde_uint32x4_to_private(val.val[0]), simde_uint32x4_to_private(val.val[1]),
                                      simde_uint32x4_to_private(val.val[2]), simde_uint32x4_to_private(val.val[3]) };
-    #if defined(SIMDE_RISCV_V_NATIVE) && (SIMDE_NATURAL_VECTOR_SIZE >= 128)
+    #if defined(SIMDE_RISCV_V_NATIVE)
       vuint32m1x4_t dest = __riscv_vlseg4e32_v_u32m1x4(ptr, 4);
       dest = __riscv_vset_v_u32m1_u32m1x4 (dest, 0, a_[0].sv128);
       dest = __riscv_vset_v_u32m1_u32m1x4 (dest, 1, a_[1].sv128);
@@ -656,7 +656,7 @@ simde_vst4q_u64(uint64_t *ptr, simde_uint64x2x4_t val) {
   #else
     simde_uint64x2_private a_[4] = { simde_uint64x2_to_private(val.val[0]), simde_uint64x2_to_private(val.val[1]),
                                      simde_uint64x2_to_private(val.val[2]), simde_uint64x2_to_private(val.val[3]) };
-    #if defined(SIMDE_RISCV_V_NATIVE) && (SIMDE_NATURAL_VECTOR_SIZE >= 128)
+    #if defined(SIMDE_RISCV_V_NATIVE)
       vuint64m1x4_t dest = __riscv_vlseg4e64_v_u64m1x4(ptr, 2);
       dest = __riscv_vset_v_u64m1_u64m1x4 (dest, 0, a_[0].sv128);
       dest = __riscv_vset_v_u64m1_u64m1x4 (dest, 1, a_[1].sv128);


### PR DESCRIPTION
Add conversion for Neon to RVV  in 13 families which are listed below:
`ld1`, `ld2`, `ld3`, `ld4`, `st2`, `st3`, `st4`, `ld1_x2`, `ld1_x3`, `ld1_x4`, `ld1q_x2`, `ld1q_x3`, `ld1q_x4`,
`st1`, `st1_x2`, `st1_x3`, `st1_x4`, `st1q_x2`, `st1q_x3`, `st1q_x4`