### PR TITLE
NEON: RVV intrinsics implementations, part8

### DIFF
--- a/simde/arm/neon/rnd.h
+++ b/simde/arm/neon/rnd.h
@@ -59,10 +59,16 @@ simde_vrnd_f16(simde_float16x4_t a) {
       r_,
       a_ = simde_float16x4_to_private(a);
 
-    SIMDE_VECTORIZE
-    for (size_t i = 0 ; i < (sizeof(r_.values) / sizeof(r_.values[0])) ; i++) {
-      r_.values[i] = simde_vrndh_f16(a_.values[i]);
-    }
+    #if defined(SIMDE_RISCV_V_NATIVE) && defined(SIMDE_ARCH_RISCV_ZVFH)
+      r_.sv64 = __riscv_vfcvt_f_x_v_f16m1(
+        __riscv_vfcvt_x_f_v_i16m1_rm(a_.sv64, 1, 4)
+        , 4);
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.values) / sizeof(r_.values[0])) ; i++) {
+        r_.values[i] = simde_vrndh_f16(a_.values[i]);
+      }
+    #endif
 
     return simde_float16x4_from_private(r_);
   #endif
@@ -82,7 +88,11 @@ simde_vrnd_f32(simde_float32x2_t a) {
       r_,
       a_ = simde_float32x2_to_private(a);
 
-    #if defined(SIMDE_VECTOR_SUBSCRIPT_OPS) && HEDLEY_HAS_BUILTIN(__builtin_elementwise_trunc)
+    #if defined(SIMDE_RISCV_V_NATIVE)
+      r_.sv64 = __riscv_vfcvt_f_x_v_f32m1(
+        __riscv_vfcvt_x_f_v_i32m1_rm(a_.sv64, 1, 2)
+        , 2);
+    #elif defined(SIMDE_VECTOR_SUBSCRIPT_OPS) && HEDLEY_HAS_BUILTIN(__builtin_elementwise_trunc)
       r_.values = __builtin_elementwise_trunc(a_.values);
     #else
       SIMDE_VECTORIZE
@@ -109,7 +119,11 @@ simde_vrnd_f64(simde_float64x1_t a) {
       r_,
       a_ = simde_float64x1_to_private(a);
 
-    #if defined(SIMDE_VECTOR_SUBSCRIPT_OPS) && HEDLEY_HAS_BUILTIN(__builtin_elementwise_trunc)
+    #if defined(SIMDE_RISCV_V_NATIVE)
+      r_.sv64 = __riscv_vfcvt_f_x_v_f64m1(
+        __riscv_vfcvt_x_f_v_i64m1_rm(a_.sv64, 1, 1)
+        , 1);
+    #elif defined(SIMDE_VECTOR_SUBSCRIPT_OPS) && HEDLEY_HAS_BUILTIN(__builtin_elementwise_trunc)
       r_.values = __builtin_elementwise_trunc(a_.values);
     #else
       SIMDE_VECTORIZE
@@ -136,10 +150,16 @@ simde_vrndq_f16(simde_float16x8_t a) {
       r_,
       a_ = simde_float16x8_to_private(a);
 
-    SIMDE_VECTORIZE
-    for (size_t i = 0 ; i < (sizeof(r_.values) / sizeof(r_.values[0])) ; i++) {
-      r_.values[i] = simde_vrndh_f16(a_.values[i]);
-    }
+    #if defined(SIMDE_RISCV_V_NATIVE) && defined(SIMDE_ARCH_RISCV_ZVFH)
+      r_.sv64 = __riscv_vfcvt_f_x_v_f16m1(
+        __riscv_vfcvt_x_f_v_i16m1_rm(a_.sv64, 1, 8)
+        , 8);
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.values) / sizeof(r_.values[0])) ; i++) {
+        r_.values[i] = simde_vrndh_f16(a_.values[i]);
+      }
+    #endif
 
     return simde_float16x8_from_private(r_);
   #endif
@@ -165,6 +185,10 @@ simde_vrndq_f32(simde_float32x4_t a) {
       r_.m128 = _mm_round_ps(a_.m128, _MM_FROUND_TO_ZERO);
     #elif defined(SIMDE_X86_SVML_NATIVE) && defined(SIMDE_X86_SSE_NATIVE)
       r_.m128 = _mm_trunc_ps(a_.m128);
+    #elif defined(SIMDE_RISCV_V_NATIVE)
+      r_.sv64 = __riscv_vfcvt_f_x_v_f32m1(
+        __riscv_vfcvt_x_f_v_i32m1_rm(a_.sv64, 1, 4)
+        , 4);
     #elif defined(SIMDE_VECTOR_SUBSCRIPT_OPS) && HEDLEY_HAS_BUILTIN(__builtin_elementwise_trunc)
       r_.values = __builtin_elementwise_trunc(a_.values);
     #else
@@ -198,6 +222,10 @@ simde_vrndq_f64(simde_float64x2_t a) {
       r_.m128d = _mm_round_pd(a_.m128d, _MM_FROUND_TO_ZERO);
     #elif defined(SIMDE_X86_SVML_NATIVE) && defined(SIMDE_X86_SSE_NATIVE)
       r_.m128d = _mm_trunc_pd(a_.m128d);
+    #elif defined(SIMDE_RISCV_V_NATIVE)
+      r_.sv64 = __riscv_vfcvt_f_x_v_f64m1(
+        __riscv_vfcvt_x_f_v_i64m1_rm(a_.sv64, 1, 2)
+        , 2);
     #elif defined(SIMDE_VECTOR_SUBSCRIPT_OPS) && HEDLEY_HAS_BUILTIN(__builtin_elementwise_trunc)
       r_.values = __builtin_elementwise_trunc(a_.values);
     #else

--- a/simde/arm/neon/rnd.h
+++ b/simde/arm/neon/rnd.h
@@ -59,7 +59,7 @@ simde_vrnd_f16(simde_float16x4_t a) {
       r_,
       a_ = simde_float16x4_to_private(a);
 
-    #if defined(SIMDE_RISCV_V_NATIVE) && defined(SIMDE_ARCH_RISCV_ZVFH)
+    #if defined(SIMDE_RISCV_V_NATIVE) && defined(SIMDE_ARCH_RISCV_ZVFH) && defined(SIMDE_FAST_NANS)
       r_.sv64 = __riscv_vfcvt_f_x_v_f16m1(
         __riscv_vfcvt_x_f_v_i16m1_rm(a_.sv64, 1, 4)
         , 4);
@@ -88,7 +88,7 @@ simde_vrnd_f32(simde_float32x2_t a) {
       r_,
       a_ = simde_float32x2_to_private(a);
 
-    #if defined(SIMDE_RISCV_V_NATIVE)
+    #if defined(SIMDE_RISCV_V_NATIVE) && defined(SIMDE_FAST_NANS)
       r_.sv64 = __riscv_vfcvt_f_x_v_f32m1(
         __riscv_vfcvt_x_f_v_i32m1_rm(a_.sv64, 1, 2)
         , 2);
@@ -119,7 +119,7 @@ simde_vrnd_f64(simde_float64x1_t a) {
       r_,
       a_ = simde_float64x1_to_private(a);
 
-    #if defined(SIMDE_RISCV_V_NATIVE)
+    #if defined(SIMDE_RISCV_V_NATIVE) && defined(SIMDE_FAST_NANS)
       r_.sv64 = __riscv_vfcvt_f_x_v_f64m1(
         __riscv_vfcvt_x_f_v_i64m1_rm(a_.sv64, 1, 1)
         , 1);
@@ -150,7 +150,7 @@ simde_vrndq_f16(simde_float16x8_t a) {
       r_,
       a_ = simde_float16x8_to_private(a);
 
-    #if defined(SIMDE_RISCV_V_NATIVE) && defined(SIMDE_ARCH_RISCV_ZVFH)
+    #if defined(SIMDE_RISCV_V_NATIVE) && defined(SIMDE_ARCH_RISCV_ZVFH) && defined(SIMDE_FAST_NANS)
       r_.sv128 = __riscv_vfcvt_f_x_v_f16m1(
         __riscv_vfcvt_x_f_v_i16m1_rm(a_.sv128, 1, 8)
         , 8);
@@ -185,7 +185,7 @@ simde_vrndq_f32(simde_float32x4_t a) {
       r_.m128 = _mm_round_ps(a_.m128, _MM_FROUND_TO_ZERO);
     #elif defined(SIMDE_X86_SVML_NATIVE) && defined(SIMDE_X86_SSE_NATIVE)
       r_.m128 = _mm_trunc_ps(a_.m128);
-    #elif defined(SIMDE_RISCV_V_NATIVE)
+    #elif defined(SIMDE_RISCV_V_NATIVE) && defined(SIMDE_FAST_NANS)
       r_.sv128 = __riscv_vfcvt_f_x_v_f32m1(
         __riscv_vfcvt_x_f_v_i32m1_rm(a_.sv128, 1, 4)
         , 4);
@@ -222,7 +222,7 @@ simde_vrndq_f64(simde_float64x2_t a) {
       r_.m128d = _mm_round_pd(a_.m128d, _MM_FROUND_TO_ZERO);
     #elif defined(SIMDE_X86_SVML_NATIVE) && defined(SIMDE_X86_SSE_NATIVE)
       r_.m128d = _mm_trunc_pd(a_.m128d);
-    #elif defined(SIMDE_RISCV_V_NATIVE)
+    #elif defined(SIMDE_RISCV_V_NATIVE) && defined(SIMDE_FAST_NANS)
       r_.sv128 = __riscv_vfcvt_f_x_v_f64m1(
         __riscv_vfcvt_x_f_v_i64m1_rm(a_.sv128, 1, 2)
         , 2);

--- a/simde/arm/neon/rnd.h
+++ b/simde/arm/neon/rnd.h
@@ -151,8 +151,8 @@ simde_vrndq_f16(simde_float16x8_t a) {
       a_ = simde_float16x8_to_private(a);
 
     #if defined(SIMDE_RISCV_V_NATIVE) && defined(SIMDE_ARCH_RISCV_ZVFH)
-      r_.sv64 = __riscv_vfcvt_f_x_v_f16m1(
-        __riscv_vfcvt_x_f_v_i16m1_rm(a_.sv64, 1, 8)
+      r_.sv128 = __riscv_vfcvt_f_x_v_f16m1(
+        __riscv_vfcvt_x_f_v_i16m1_rm(a_.sv128, 1, 8)
         , 8);
     #else
       SIMDE_VECTORIZE
@@ -186,8 +186,8 @@ simde_vrndq_f32(simde_float32x4_t a) {
     #elif defined(SIMDE_X86_SVML_NATIVE) && defined(SIMDE_X86_SSE_NATIVE)
       r_.m128 = _mm_trunc_ps(a_.m128);
     #elif defined(SIMDE_RISCV_V_NATIVE)
-      r_.sv64 = __riscv_vfcvt_f_x_v_f32m1(
-        __riscv_vfcvt_x_f_v_i32m1_rm(a_.sv64, 1, 4)
+      r_.sv128 = __riscv_vfcvt_f_x_v_f32m1(
+        __riscv_vfcvt_x_f_v_i32m1_rm(a_.sv128, 1, 4)
         , 4);
     #elif defined(SIMDE_VECTOR_SUBSCRIPT_OPS) && HEDLEY_HAS_BUILTIN(__builtin_elementwise_trunc)
       r_.values = __builtin_elementwise_trunc(a_.values);
@@ -223,8 +223,8 @@ simde_vrndq_f64(simde_float64x2_t a) {
     #elif defined(SIMDE_X86_SVML_NATIVE) && defined(SIMDE_X86_SSE_NATIVE)
       r_.m128d = _mm_trunc_pd(a_.m128d);
     #elif defined(SIMDE_RISCV_V_NATIVE)
-      r_.sv64 = __riscv_vfcvt_f_x_v_f64m1(
-        __riscv_vfcvt_x_f_v_i64m1_rm(a_.sv64, 1, 2)
+      r_.sv128 = __riscv_vfcvt_f_x_v_f64m1(
+        __riscv_vfcvt_x_f_v_i64m1_rm(a_.sv128, 1, 2)
         , 2);
     #elif defined(SIMDE_VECTOR_SUBSCRIPT_OPS) && HEDLEY_HAS_BUILTIN(__builtin_elementwise_trunc)
       r_.values = __builtin_elementwise_trunc(a_.values);

--- a/simde/arm/neon/rndm.h
+++ b/simde/arm/neon/rndm.h
@@ -151,8 +151,8 @@ simde_vrndmq_f16(simde_float16x8_t a) {
       a_ = simde_float16x8_to_private(a);
 
     #if defined(SIMDE_RISCV_V_NATIVE) && defined(SIMDE_ARCH_RISCV_ZVFH)
-      r_.sv64 = __riscv_vfcvt_f_x_v_f16m1(
-        __riscv_vfcvt_x_f_v_i16m1_rm(a_.sv64, 2, 8)
+      r_.sv128 = __riscv_vfcvt_f_x_v_f16m1(
+        __riscv_vfcvt_x_f_v_i16m1_rm(a_.sv128, 2, 8)
         , 8);
     #else
       SIMDE_VECTORIZE
@@ -186,8 +186,8 @@ simde_vrndmq_f32(simde_float32x4_t a) {
     #elif defined(SIMDE_X86_SVML_NATIVE) && defined(SIMDE_X86_SSE_NATIVE)
       r_.m128 = _mm_floor_ps(a_.m128);
     #elif defined(SIMDE_RISCV_V_NATIVE)
-      r_.sv64 = __riscv_vfcvt_f_x_v_f32m1(
-        __riscv_vfcvt_x_f_v_i32m1_rm(a_.sv64, 2, 4)
+      r_.sv128 = __riscv_vfcvt_f_x_v_f32m1(
+        __riscv_vfcvt_x_f_v_i32m1_rm(a_.sv128, 2, 4)
         , 4);
     #elif defined(SIMDE_VECTOR_SUBSCRIPT_OPS) && HEDLEY_HAS_BUILTIN(__builtin_elementwise_floor)
       r_.values = __builtin_elementwise_floor(a_.values);
@@ -223,8 +223,8 @@ simde_vrndmq_f64(simde_float64x2_t a) {
     #elif defined(SIMDE_X86_SVML_NATIVE) && defined(SIMDE_X86_SSE_NATIVE)
       r_.m128d = _mm_floor_pd(a_.m128d);
     #elif defined(SIMDE_RISCV_V_NATIVE)
-      r_.sv64 = __riscv_vfcvt_f_x_v_f64m1(
-        __riscv_vfcvt_x_f_v_i64m1_rm(a_.sv64, 2, 2)
+      r_.sv128 = __riscv_vfcvt_f_x_v_f64m1(
+        __riscv_vfcvt_x_f_v_i64m1_rm(a_.sv128, 2, 2)
         , 2);
     #elif defined(SIMDE_VECTOR_SUBSCRIPT_OPS) && HEDLEY_HAS_BUILTIN(__builtin_elementwise_floor)
       r_.values = __builtin_elementwise_floor(a_.values);

--- a/simde/arm/neon/rndm.h
+++ b/simde/arm/neon/rndm.h
@@ -59,7 +59,7 @@ simde_vrndm_f16(simde_float16x4_t a) {
       r_,
       a_ = simde_float16x4_to_private(a);
 
-    #if defined(SIMDE_RISCV_V_NATIVE) && defined(SIMDE_ARCH_RISCV_ZVFH)
+    #if defined(SIMDE_RISCV_V_NATIVE) && defined(SIMDE_ARCH_RISCV_ZVFH) && defined(SIMDE_FAST_NANS)
       r_.sv64 = __riscv_vfcvt_f_x_v_f16m1(
         __riscv_vfcvt_x_f_v_i16m1_rm(a_.sv64, 2, 4)
         , 4);
@@ -88,7 +88,7 @@ simde_vrndm_f32(simde_float32x2_t a) {
       r_,
       a_ = simde_float32x2_to_private(a);
 
-    #if defined(SIMDE_RISCV_V_NATIVE)
+    #if defined(SIMDE_RISCV_V_NATIVE) && defined(SIMDE_FAST_NANS)
       r_.sv64 = __riscv_vfcvt_f_x_v_f32m1(
         __riscv_vfcvt_x_f_v_i32m1_rm(a_.sv64, 2, 2)
         , 2);
@@ -119,7 +119,7 @@ simde_vrndm_f64(simde_float64x1_t a) {
       r_,
       a_ = simde_float64x1_to_private(a);
 
-    #if defined(SIMDE_RISCV_V_NATIVE)
+    #if defined(SIMDE_RISCV_V_NATIVE) && defined(SIMDE_FAST_NANS)
       r_.sv64 = __riscv_vfcvt_f_x_v_f64m1(
         __riscv_vfcvt_x_f_v_i64m1_rm(a_.sv64, 2, 1)
         , 1);
@@ -150,7 +150,7 @@ simde_vrndmq_f16(simde_float16x8_t a) {
       r_,
       a_ = simde_float16x8_to_private(a);
 
-    #if defined(SIMDE_RISCV_V_NATIVE) && defined(SIMDE_ARCH_RISCV_ZVFH)
+    #if defined(SIMDE_RISCV_V_NATIVE) && defined(SIMDE_ARCH_RISCV_ZVFH) && defined(SIMDE_FAST_NANS)
       r_.sv128 = __riscv_vfcvt_f_x_v_f16m1(
         __riscv_vfcvt_x_f_v_i16m1_rm(a_.sv128, 2, 8)
         , 8);
@@ -185,7 +185,7 @@ simde_vrndmq_f32(simde_float32x4_t a) {
       r_.m128 = _mm_round_ps(a_.m128, _MM_FROUND_TO_NEG_INF);
     #elif defined(SIMDE_X86_SVML_NATIVE) && defined(SIMDE_X86_SSE_NATIVE)
       r_.m128 = _mm_floor_ps(a_.m128);
-    #elif defined(SIMDE_RISCV_V_NATIVE)
+    #elif defined(SIMDE_RISCV_V_NATIVE) && defined(SIMDE_FAST_NANS)
       r_.sv128 = __riscv_vfcvt_f_x_v_f32m1(
         __riscv_vfcvt_x_f_v_i32m1_rm(a_.sv128, 2, 4)
         , 4);
@@ -222,7 +222,7 @@ simde_vrndmq_f64(simde_float64x2_t a) {
       r_.m128d = _mm_round_pd(a_.m128d, _MM_FROUND_TO_NEG_INF);
     #elif defined(SIMDE_X86_SVML_NATIVE) && defined(SIMDE_X86_SSE_NATIVE)
       r_.m128d = _mm_floor_pd(a_.m128d);
-    #elif defined(SIMDE_RISCV_V_NATIVE)
+    #elif defined(SIMDE_RISCV_V_NATIVE) && defined(SIMDE_FAST_NANS)
       r_.sv128 = __riscv_vfcvt_f_x_v_f64m1(
         __riscv_vfcvt_x_f_v_i64m1_rm(a_.sv128, 2, 2)
         , 2);

--- a/simde/arm/neon/rndm.h
+++ b/simde/arm/neon/rndm.h
@@ -59,10 +59,16 @@ simde_vrndm_f16(simde_float16x4_t a) {
       r_,
       a_ = simde_float16x4_to_private(a);
 
-    SIMDE_VECTORIZE
-    for (size_t i = 0 ; i < (sizeof(r_.values) / sizeof(r_.values[0])) ; i++) {
-      r_.values[i] = simde_vrndmh_f16(a_.values[i]);
-    }
+    #if defined(SIMDE_RISCV_V_NATIVE) && defined(SIMDE_ARCH_RISCV_ZVFH)
+      r_.sv64 = __riscv_vfcvt_f_x_v_f16m1(
+        __riscv_vfcvt_x_f_v_i16m1_rm(a_.sv64, 2, 4)
+        , 4);
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.values) / sizeof(r_.values[0])) ; i++) {
+        r_.values[i] = simde_vrndmh_f16(a_.values[i]);
+      }
+    #endif
 
     return simde_float16x4_from_private(r_);
   #endif
@@ -82,7 +88,11 @@ simde_vrndm_f32(simde_float32x2_t a) {
       r_,
       a_ = simde_float32x2_to_private(a);
 
-    #if defined(SIMDE_VECTOR_SUBSCRIPT_OPS) && HEDLEY_HAS_BUILTIN(__builtin_elementwise_floor)
+    #if defined(SIMDE_RISCV_V_NATIVE)
+      r_.sv64 = __riscv_vfcvt_f_x_v_f32m1(
+        __riscv_vfcvt_x_f_v_i32m1_rm(a_.sv64, 2, 2)
+        , 2);
+    #elif defined(SIMDE_VECTOR_SUBSCRIPT_OPS) && HEDLEY_HAS_BUILTIN(__builtin_elementwise_floor)
       r_.values = __builtin_elementwise_floor(a_.values);
     #else
       SIMDE_VECTORIZE
@@ -109,7 +119,11 @@ simde_vrndm_f64(simde_float64x1_t a) {
       r_,
       a_ = simde_float64x1_to_private(a);
 
-    #if defined(SIMDE_VECTOR_SUBSCRIPT_OPS) && HEDLEY_HAS_BUILTIN(__builtin_elementwise_floor)
+    #if defined(SIMDE_RISCV_V_NATIVE)
+      r_.sv64 = __riscv_vfcvt_f_x_v_f64m1(
+        __riscv_vfcvt_x_f_v_i64m1_rm(a_.sv64, 2, 1)
+        , 1);
+    #elif defined(SIMDE_VECTOR_SUBSCRIPT_OPS) && HEDLEY_HAS_BUILTIN(__builtin_elementwise_floor)
       r_.values = __builtin_elementwise_floor(a_.values);
     #else
       SIMDE_VECTORIZE
@@ -136,10 +150,16 @@ simde_vrndmq_f16(simde_float16x8_t a) {
       r_,
       a_ = simde_float16x8_to_private(a);
 
-    SIMDE_VECTORIZE
-    for (size_t i = 0 ; i < (sizeof(r_.values) / sizeof(r_.values[0])) ; i++) {
-      r_.values[i] = simde_vrndmh_f16(a_.values[i]);
-    }
+    #if defined(SIMDE_RISCV_V_NATIVE) && defined(SIMDE_ARCH_RISCV_ZVFH)
+      r_.sv64 = __riscv_vfcvt_f_x_v_f16m1(
+        __riscv_vfcvt_x_f_v_i16m1_rm(a_.sv64, 2, 8)
+        , 8);
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.values) / sizeof(r_.values[0])) ; i++) {
+        r_.values[i] = simde_vrndmh_f16(a_.values[i]);
+      }
+    #endif
 
     return simde_float16x8_from_private(r_);
   #endif
@@ -165,6 +185,10 @@ simde_vrndmq_f32(simde_float32x4_t a) {
       r_.m128 = _mm_round_ps(a_.m128, _MM_FROUND_TO_NEG_INF);
     #elif defined(SIMDE_X86_SVML_NATIVE) && defined(SIMDE_X86_SSE_NATIVE)
       r_.m128 = _mm_floor_ps(a_.m128);
+    #elif defined(SIMDE_RISCV_V_NATIVE)
+      r_.sv64 = __riscv_vfcvt_f_x_v_f32m1(
+        __riscv_vfcvt_x_f_v_i32m1_rm(a_.sv64, 2, 4)
+        , 4);
     #elif defined(SIMDE_VECTOR_SUBSCRIPT_OPS) && HEDLEY_HAS_BUILTIN(__builtin_elementwise_floor)
       r_.values = __builtin_elementwise_floor(a_.values);
     #else
@@ -198,6 +222,10 @@ simde_vrndmq_f64(simde_float64x2_t a) {
       r_.m128d = _mm_round_pd(a_.m128d, _MM_FROUND_TO_NEG_INF);
     #elif defined(SIMDE_X86_SVML_NATIVE) && defined(SIMDE_X86_SSE_NATIVE)
       r_.m128d = _mm_floor_pd(a_.m128d);
+    #elif defined(SIMDE_RISCV_V_NATIVE)
+      r_.sv64 = __riscv_vfcvt_f_x_v_f64m1(
+        __riscv_vfcvt_x_f_v_i64m1_rm(a_.sv64, 2, 2)
+        , 2);
     #elif defined(SIMDE_VECTOR_SUBSCRIPT_OPS) && HEDLEY_HAS_BUILTIN(__builtin_elementwise_floor)
       r_.values = __builtin_elementwise_floor(a_.values);
     #else

--- a/simde/arm/neon/rndn.h
+++ b/simde/arm/neon/rndn.h
@@ -80,10 +80,16 @@ simde_vrndn_f16(simde_float16x4_t a) {
       r_,
       a_ = simde_float16x4_to_private(a);
 
-    SIMDE_VECTORIZE
-    for (size_t i = 0 ; i < (sizeof(r_.values) / sizeof(r_.values[0])) ; i++) {
-      r_.values[i] = simde_vrndnh_f16(a_.values[i]);
-    }
+    #if defined(SIMDE_RISCV_V_NATIVE) && defined(SIMDE_ARCH_RISCV_ZVFH)
+      r_.sv64 = __riscv_vfcvt_f_x_v_f16m1(
+        __riscv_vfcvt_x_f_v_i16m1_rm(a_.sv64, 0, 4)
+        , 4);
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.values) / sizeof(r_.values[0])) ; i++) {
+        r_.values[i] = simde_vrndnh_f16(a_.values[i]);
+      }
+    #endif
 
     return simde_float16x4_from_private(r_);
   #endif
@@ -102,7 +108,12 @@ simde_vrndn_f32(simde_float32x2_t a) {
     simde_float32x2_private
       r_,
       a_ = simde_float32x2_to_private(a);
-    #if defined(SIMDE_VECTOR_SUBSCRIPT_OPS) && HEDLEY_HAS_BUILTIN(__builtin_elementwise_roundeven)
+
+    #if defined(SIMDE_RISCV_V_NATIVE)
+      r_.sv64 = __riscv_vfcvt_f_x_v_f32m1(
+        __riscv_vfcvt_x_f_v_i32m1_rm(a_.sv64, 0, 2)
+        , 2);
+    #elif defined(SIMDE_VECTOR_SUBSCRIPT_OPS) && HEDLEY_HAS_BUILTIN(__builtin_elementwise_roundeven)
       r_.values = __builtin_elementwise_roundeven(a_.values);
     #else
       SIMDE_VECTORIZE
@@ -130,7 +141,11 @@ simde_vrndn_f64(simde_float64x1_t a) {
       r_,
       a_ = simde_float64x1_to_private(a);
 
-    #if defined(SIMDE_VECTOR_SUBSCRIPT_OPS) && HEDLEY_HAS_BUILTIN(__builtin_elementwise_roundeven)
+    #if defined(SIMDE_RISCV_V_NATIVE)
+      r_.sv64 = __riscv_vfcvt_f_x_v_f64m1(
+        __riscv_vfcvt_x_f_v_i64m1_rm(a_.sv64, 0, 1)
+        , 1);
+    #elif defined(SIMDE_VECTOR_SUBSCRIPT_OPS) && HEDLEY_HAS_BUILTIN(__builtin_elementwise_roundeven)
       r_.values = __builtin_elementwise_roundeven(a_.values);
     #else
       SIMDE_VECTORIZE
@@ -157,10 +172,16 @@ simde_vrndnq_f16(simde_float16x8_t a) {
       r_,
       a_ = simde_float16x8_to_private(a);
 
-    SIMDE_VECTORIZE
-    for (size_t i = 0 ; i < (sizeof(r_.values) / sizeof(r_.values[0])) ; i++) {
-      r_.values[i] = simde_vrndnh_f16(a_.values[i]);
-    }
+    #if defined(SIMDE_RISCV_V_NATIVE) && defined(SIMDE_ARCH_RISCV_ZVFH)
+      r_.sv64 = __riscv_vfcvt_f_x_v_f16m1(
+        __riscv_vfcvt_x_f_v_i16m1_rm(a_.sv64, 0, 8)
+        , 8);
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.values) / sizeof(r_.values[0])) ; i++) {
+        r_.values[i] = simde_vrndnh_f16(a_.values[i]);
+      }
+    #endif
 
     return simde_float16x8_from_private(r_);
   #endif
@@ -182,6 +203,10 @@ simde_vrndnq_f32(simde_float32x4_t a) {
 
     #if defined(SIMDE_X86_SSE4_1_NATIVE)
       r_.m128 = _mm_round_ps(a_.m128, _MM_FROUND_TO_NEAREST_INT);
+    #elif defined(SIMDE_RISCV_V_NATIVE)
+      r_.sv64 = __riscv_vfcvt_f_x_v_f32m1(
+        __riscv_vfcvt_x_f_v_i32m1_rm(a_.sv64, 0, 4)
+        , 4);
     #elif defined(SIMDE_VECTOR_SUBSCRIPT_OPS) && HEDLEY_HAS_BUILTIN(__builtin_elementwise_roundeven)
       r_.values = __builtin_elementwise_roundeven(a_.values);
     #else
@@ -212,6 +237,10 @@ simde_vrndnq_f64(simde_float64x2_t a) {
 
     #if defined(SIMDE_X86_SSE4_1_NATIVE)
       r_.m128d = _mm_round_pd(a_.m128d, _MM_FROUND_TO_NEAREST_INT);
+    #elif defined(SIMDE_RISCV_V_NATIVE)
+      r_.sv64 = __riscv_vfcvt_f_x_v_f64m1(
+        __riscv_vfcvt_x_f_v_i64m1_rm(a_.sv64, 0, 2)
+        , 2);
     #elif defined(SIMDE_VECTOR_SUBSCRIPT_OPS) && HEDLEY_HAS_BUILTIN(__builtin_elementwise_roundeven)
       r_.values = __builtin_elementwise_roundeven(a_.values);
     #else

--- a/simde/arm/neon/rndn.h
+++ b/simde/arm/neon/rndn.h
@@ -80,7 +80,7 @@ simde_vrndn_f16(simde_float16x4_t a) {
       r_,
       a_ = simde_float16x4_to_private(a);
 
-    #if defined(SIMDE_RISCV_V_NATIVE) && defined(SIMDE_ARCH_RISCV_ZVFH)
+    #if defined(SIMDE_RISCV_V_NATIVE) && defined(SIMDE_ARCH_RISCV_ZVFH) && defined(SIMDE_FAST_NANS)
       r_.sv64 = __riscv_vfcvt_f_x_v_f16m1(
         __riscv_vfcvt_x_f_v_i16m1_rm(a_.sv64, 0, 4)
         , 4);
@@ -109,7 +109,7 @@ simde_vrndn_f32(simde_float32x2_t a) {
       r_,
       a_ = simde_float32x2_to_private(a);
 
-    #if defined(SIMDE_RISCV_V_NATIVE)
+    #if defined(SIMDE_RISCV_V_NATIVE) && defined(SIMDE_FAST_NANS)
       r_.sv64 = __riscv_vfcvt_f_x_v_f32m1(
         __riscv_vfcvt_x_f_v_i32m1_rm(a_.sv64, 0, 2)
         , 2);
@@ -141,7 +141,7 @@ simde_vrndn_f64(simde_float64x1_t a) {
       r_,
       a_ = simde_float64x1_to_private(a);
 
-    #if defined(SIMDE_RISCV_V_NATIVE)
+    #if defined(SIMDE_RISCV_V_NATIVE) && defined(SIMDE_FAST_NANS)
       r_.sv64 = __riscv_vfcvt_f_x_v_f64m1(
         __riscv_vfcvt_x_f_v_i64m1_rm(a_.sv64, 0, 1)
         , 1);
@@ -172,7 +172,7 @@ simde_vrndnq_f16(simde_float16x8_t a) {
       r_,
       a_ = simde_float16x8_to_private(a);
 
-    #if defined(SIMDE_RISCV_V_NATIVE) && defined(SIMDE_ARCH_RISCV_ZVFH)
+    #if defined(SIMDE_RISCV_V_NATIVE) && defined(SIMDE_ARCH_RISCV_ZVFH) && defined(SIMDE_FAST_NANS)
       r_.sv128 = __riscv_vfcvt_f_x_v_f16m1(
         __riscv_vfcvt_x_f_v_i16m1_rm(a_.sv128, 0, 8)
         , 8);
@@ -203,7 +203,7 @@ simde_vrndnq_f32(simde_float32x4_t a) {
 
     #if defined(SIMDE_X86_SSE4_1_NATIVE)
       r_.m128 = _mm_round_ps(a_.m128, _MM_FROUND_TO_NEAREST_INT);
-    #elif defined(SIMDE_RISCV_V_NATIVE)
+    #elif defined(SIMDE_RISCV_V_NATIVE) && defined(SIMDE_FAST_NANS)
       r_.sv128 = __riscv_vfcvt_f_x_v_f32m1(
         __riscv_vfcvt_x_f_v_i32m1_rm(a_.sv128, 0, 4)
         , 4);
@@ -237,7 +237,7 @@ simde_vrndnq_f64(simde_float64x2_t a) {
 
     #if defined(SIMDE_X86_SSE4_1_NATIVE)
       r_.m128d = _mm_round_pd(a_.m128d, _MM_FROUND_TO_NEAREST_INT);
-    #elif defined(SIMDE_RISCV_V_NATIVE)
+    #elif defined(SIMDE_RISCV_V_NATIVE) && defined(SIMDE_FAST_NANS)
       r_.sv128 = __riscv_vfcvt_f_x_v_f64m1(
         __riscv_vfcvt_x_f_v_i64m1_rm(a_.sv128, 0, 2)
         , 2);

--- a/simde/arm/neon/rndn.h
+++ b/simde/arm/neon/rndn.h
@@ -173,8 +173,8 @@ simde_vrndnq_f16(simde_float16x8_t a) {
       a_ = simde_float16x8_to_private(a);
 
     #if defined(SIMDE_RISCV_V_NATIVE) && defined(SIMDE_ARCH_RISCV_ZVFH)
-      r_.sv64 = __riscv_vfcvt_f_x_v_f16m1(
-        __riscv_vfcvt_x_f_v_i16m1_rm(a_.sv64, 0, 8)
+      r_.sv128 = __riscv_vfcvt_f_x_v_f16m1(
+        __riscv_vfcvt_x_f_v_i16m1_rm(a_.sv128, 0, 8)
         , 8);
     #else
       SIMDE_VECTORIZE
@@ -204,8 +204,8 @@ simde_vrndnq_f32(simde_float32x4_t a) {
     #if defined(SIMDE_X86_SSE4_1_NATIVE)
       r_.m128 = _mm_round_ps(a_.m128, _MM_FROUND_TO_NEAREST_INT);
     #elif defined(SIMDE_RISCV_V_NATIVE)
-      r_.sv64 = __riscv_vfcvt_f_x_v_f32m1(
-        __riscv_vfcvt_x_f_v_i32m1_rm(a_.sv64, 0, 4)
+      r_.sv128 = __riscv_vfcvt_f_x_v_f32m1(
+        __riscv_vfcvt_x_f_v_i32m1_rm(a_.sv128, 0, 4)
         , 4);
     #elif defined(SIMDE_VECTOR_SUBSCRIPT_OPS) && HEDLEY_HAS_BUILTIN(__builtin_elementwise_roundeven)
       r_.values = __builtin_elementwise_roundeven(a_.values);
@@ -238,8 +238,8 @@ simde_vrndnq_f64(simde_float64x2_t a) {
     #if defined(SIMDE_X86_SSE4_1_NATIVE)
       r_.m128d = _mm_round_pd(a_.m128d, _MM_FROUND_TO_NEAREST_INT);
     #elif defined(SIMDE_RISCV_V_NATIVE)
-      r_.sv64 = __riscv_vfcvt_f_x_v_f64m1(
-        __riscv_vfcvt_x_f_v_i64m1_rm(a_.sv64, 0, 2)
+      r_.sv128 = __riscv_vfcvt_f_x_v_f64m1(
+        __riscv_vfcvt_x_f_v_i64m1_rm(a_.sv128, 0, 2)
         , 2);
     #elif defined(SIMDE_VECTOR_SUBSCRIPT_OPS) && HEDLEY_HAS_BUILTIN(__builtin_elementwise_roundeven)
       r_.values = __builtin_elementwise_roundeven(a_.values);

--- a/simde/arm/neon/rndp.h
+++ b/simde/arm/neon/rndp.h
@@ -59,7 +59,7 @@ simde_vrndp_f16(simde_float16x4_t a) {
       r_,
       a_ = simde_float16x4_to_private(a);
 
-    #if defined(SIMDE_RISCV_V_NATIVE) && defined(SIMDE_ARCH_RISCV_ZVFH)
+    #if defined(SIMDE_RISCV_V_NATIVE) && defined(SIMDE_ARCH_RISCV_ZVFH) && defined(SIMDE_FAST_NANS)
       r_.sv64 = __riscv_vfcvt_f_x_v_f16m1(
         __riscv_vfcvt_x_f_v_i16m1_rm(a_.sv64, 3, 4)
         , 4);
@@ -88,7 +88,7 @@ simde_vrndp_f32(simde_float32x2_t a) {
       r_,
       a_ = simde_float32x2_to_private(a);
 
-    #if defined(SIMDE_RISCV_V_NATIVE)
+    #if defined(SIMDE_RISCV_V_NATIVE) && defined(SIMDE_FAST_NANS)
       r_.sv64 = __riscv_vfcvt_f_x_v_f32m1(
         __riscv_vfcvt_x_f_v_i32m1_rm(a_.sv64, 3, 2)
         , 2);
@@ -119,7 +119,7 @@ simde_vrndp_f64(simde_float64x1_t a) {
       r_,
       a_ = simde_float64x1_to_private(a);
 
-    #if defined(SIMDE_RISCV_V_NATIVE)
+    #if defined(SIMDE_RISCV_V_NATIVE) && defined(SIMDE_FAST_NANS)
       r_.sv64 = __riscv_vfcvt_f_x_v_f64m1(
         __riscv_vfcvt_x_f_v_i64m1_rm(a_.sv64, 3, 1)
         , 1);
@@ -150,7 +150,7 @@ simde_vrndpq_f16(simde_float16x8_t a) {
       r_,
       a_ = simde_float16x8_to_private(a);
 
-    #if defined(SIMDE_RISCV_V_NATIVE) && defined(SIMDE_ARCH_RISCV_ZVFH)
+    #if defined(SIMDE_RISCV_V_NATIVE) && defined(SIMDE_ARCH_RISCV_ZVFH) && defined(SIMDE_FAST_NANS)
       r_.sv128 = __riscv_vfcvt_f_x_v_f16m1(
         __riscv_vfcvt_x_f_v_i16m1_rm(a_.sv128, 3, 8)
         , 8);
@@ -185,7 +185,7 @@ simde_vrndpq_f32(simde_float32x4_t a) {
       r_.m128 = _mm_round_ps(a_.m128, _MM_FROUND_TO_POS_INF);
     #elif defined(SIMDE_X86_SVML_NATIVE) && defined(SIMDE_X86_SSE_NATIVE)
       r_.m128 = _mm_ceil_ps(a_.m128);
-    #elif defined(SIMDE_RISCV_V_NATIVE)
+    #elif defined(SIMDE_RISCV_V_NATIVE) && defined(SIMDE_FAST_NANS)
       r_.sv128 = __riscv_vfcvt_f_x_v_f32m1(
         __riscv_vfcvt_x_f_v_i32m1_rm(a_.sv128, 3, 4)
         , 4);
@@ -222,7 +222,7 @@ simde_vrndpq_f64(simde_float64x2_t a) {
       r_.m128d = _mm_round_pd(a_.m128d, _MM_FROUND_TO_POS_INF);
     #elif defined(SIMDE_X86_SVML_NATIVE) && defined(SIMDE_X86_SSE_NATIVE)
       r_.m128d = _mm_ceil_pd(a_.m128d);
-    #elif defined(SIMDE_RISCV_V_NATIVE)
+    #elif defined(SIMDE_RISCV_V_NATIVE) && defined(SIMDE_FAST_NANS)
       r_.sv128 = __riscv_vfcvt_f_x_v_f64m1(
         __riscv_vfcvt_x_f_v_i64m1_rm(a_.sv128, 3, 2)
         , 2);

--- a/simde/arm/neon/rndp.h
+++ b/simde/arm/neon/rndp.h
@@ -151,8 +151,8 @@ simde_vrndpq_f16(simde_float16x8_t a) {
       a_ = simde_float16x8_to_private(a);
 
     #if defined(SIMDE_RISCV_V_NATIVE) && defined(SIMDE_ARCH_RISCV_ZVFH)
-      r_.sv64 = __riscv_vfcvt_f_x_v_f16m1(
-        __riscv_vfcvt_x_f_v_i16m1_rm(a_.sv64, 3, 8)
+      r_.sv128 = __riscv_vfcvt_f_x_v_f16m1(
+        __riscv_vfcvt_x_f_v_i16m1_rm(a_.sv128, 3, 8)
         , 8);
     #else
       SIMDE_VECTORIZE
@@ -186,8 +186,8 @@ simde_vrndpq_f32(simde_float32x4_t a) {
     #elif defined(SIMDE_X86_SVML_NATIVE) && defined(SIMDE_X86_SSE_NATIVE)
       r_.m128 = _mm_ceil_ps(a_.m128);
     #elif defined(SIMDE_RISCV_V_NATIVE)
-      r_.sv64 = __riscv_vfcvt_f_x_v_f32m1(
-        __riscv_vfcvt_x_f_v_i32m1_rm(a_.sv64, 3, 4)
+      r_.sv128 = __riscv_vfcvt_f_x_v_f32m1(
+        __riscv_vfcvt_x_f_v_i32m1_rm(a_.sv128, 3, 4)
         , 4);
     #elif defined(SIMDE_VECTOR_SUBSCRIPT_OPS) && HEDLEY_HAS_BUILTIN(__builtin_elementwise_ceil)
       r_.values = __builtin_elementwise_ceil(a_.values);
@@ -223,8 +223,8 @@ simde_vrndpq_f64(simde_float64x2_t a) {
     #elif defined(SIMDE_X86_SVML_NATIVE) && defined(SIMDE_X86_SSE_NATIVE)
       r_.m128d = _mm_ceil_pd(a_.m128d);
     #elif defined(SIMDE_RISCV_V_NATIVE)
-      r_.sv64 = __riscv_vfcvt_f_x_v_f64m1(
-        __riscv_vfcvt_x_f_v_i64m1_rm(a_.sv64, 3, 2)
+      r_.sv128 = __riscv_vfcvt_f_x_v_f64m1(
+        __riscv_vfcvt_x_f_v_i64m1_rm(a_.sv128, 3, 2)
         , 2);
     #elif defined(SIMDE_VECTOR_SUBSCRIPT_OPS) && HEDLEY_HAS_BUILTIN(__builtin_elementwise_ceil)
       r_.values = __builtin_elementwise_ceil(a_.values);

--- a/simde/arm/neon/rndp.h
+++ b/simde/arm/neon/rndp.h
@@ -59,10 +59,16 @@ simde_vrndp_f16(simde_float16x4_t a) {
       r_,
       a_ = simde_float16x4_to_private(a);
 
-    SIMDE_VECTORIZE
-    for (size_t i = 0 ; i < (sizeof(r_.values) / sizeof(r_.values[0])) ; i++) {
-      r_.values[i] = simde_vrndph_f16(a_.values[i]);
-    }
+    #if defined(SIMDE_RISCV_V_NATIVE) && defined(SIMDE_ARCH_RISCV_ZVFH)
+      r_.sv64 = __riscv_vfcvt_f_x_v_f16m1(
+        __riscv_vfcvt_x_f_v_i16m1_rm(a_.sv64, 3, 4)
+        , 4);
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.values) / sizeof(r_.values[0])) ; i++) {
+        r_.values[i] = simde_vrndph_f16(a_.values[i]);
+      }
+    #endif
 
     return simde_float16x4_from_private(r_);
   #endif
@@ -82,7 +88,11 @@ simde_vrndp_f32(simde_float32x2_t a) {
       r_,
       a_ = simde_float32x2_to_private(a);
 
-    #if defined(SIMDE_VECTOR_SUBSCRIPT_OPS) && HEDLEY_HAS_BUILTIN(__builtin_elementwise_ceil)
+    #if defined(SIMDE_RISCV_V_NATIVE)
+      r_.sv64 = __riscv_vfcvt_f_x_v_f32m1(
+        __riscv_vfcvt_x_f_v_i32m1_rm(a_.sv64, 3, 2)
+        , 2);
+    #elif defined(SIMDE_VECTOR_SUBSCRIPT_OPS) && HEDLEY_HAS_BUILTIN(__builtin_elementwise_ceil)
       r_.values = __builtin_elementwise_ceil(a_.values);
     #else
       SIMDE_VECTORIZE
@@ -109,7 +119,11 @@ simde_vrndp_f64(simde_float64x1_t a) {
       r_,
       a_ = simde_float64x1_to_private(a);
 
-    #if defined(SIMDE_VECTOR_SUBSCRIPT_OPS) && HEDLEY_HAS_BUILTIN(__builtin_elementwise_ceil)
+    #if defined(SIMDE_RISCV_V_NATIVE)
+      r_.sv64 = __riscv_vfcvt_f_x_v_f64m1(
+        __riscv_vfcvt_x_f_v_i64m1_rm(a_.sv64, 3, 1)
+        , 1);
+    #elif defined(SIMDE_VECTOR_SUBSCRIPT_OPS) && HEDLEY_HAS_BUILTIN(__builtin_elementwise_ceil)
       r_.values = __builtin_elementwise_ceil(a_.values);
     #else
       SIMDE_VECTORIZE
@@ -136,10 +150,16 @@ simde_vrndpq_f16(simde_float16x8_t a) {
       r_,
       a_ = simde_float16x8_to_private(a);
 
-    SIMDE_VECTORIZE
-    for (size_t i = 0 ; i < (sizeof(r_.values) / sizeof(r_.values[0])) ; i++) {
-      r_.values[i] = simde_vrndph_f16(a_.values[i]);
-    }
+    #if defined(SIMDE_RISCV_V_NATIVE) && defined(SIMDE_ARCH_RISCV_ZVFH)
+      r_.sv64 = __riscv_vfcvt_f_x_v_f16m1(
+        __riscv_vfcvt_x_f_v_i16m1_rm(a_.sv64, 3, 8)
+        , 8);
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.values) / sizeof(r_.values[0])) ; i++) {
+        r_.values[i] = simde_vrndph_f16(a_.values[i]);
+      }
+    #endif
 
     return simde_float16x8_from_private(r_);
   #endif
@@ -165,6 +185,10 @@ simde_vrndpq_f32(simde_float32x4_t a) {
       r_.m128 = _mm_round_ps(a_.m128, _MM_FROUND_TO_POS_INF);
     #elif defined(SIMDE_X86_SVML_NATIVE) && defined(SIMDE_X86_SSE_NATIVE)
       r_.m128 = _mm_ceil_ps(a_.m128);
+    #elif defined(SIMDE_RISCV_V_NATIVE)
+      r_.sv64 = __riscv_vfcvt_f_x_v_f32m1(
+        __riscv_vfcvt_x_f_v_i32m1_rm(a_.sv64, 3, 4)
+        , 4);
     #elif defined(SIMDE_VECTOR_SUBSCRIPT_OPS) && HEDLEY_HAS_BUILTIN(__builtin_elementwise_ceil)
       r_.values = __builtin_elementwise_ceil(a_.values);
     #else
@@ -198,6 +222,10 @@ simde_vrndpq_f64(simde_float64x2_t a) {
       r_.m128d = _mm_round_pd(a_.m128d, _MM_FROUND_TO_POS_INF);
     #elif defined(SIMDE_X86_SVML_NATIVE) && defined(SIMDE_X86_SSE_NATIVE)
       r_.m128d = _mm_ceil_pd(a_.m128d);
+    #elif defined(SIMDE_RISCV_V_NATIVE)
+      r_.sv64 = __riscv_vfcvt_f_x_v_f64m1(
+        __riscv_vfcvt_x_f_v_i64m1_rm(a_.sv64, 3, 2)
+        , 2);
     #elif defined(SIMDE_VECTOR_SUBSCRIPT_OPS) && HEDLEY_HAS_BUILTIN(__builtin_elementwise_ceil)
       r_.values = __builtin_elementwise_ceil(a_.values);
     #else


### PR DESCRIPTION
Add conversion for Neon to RVV in 4 families which are listed below:

`rnd`, `rndm`, `rndp`, `rndn`