### PR TITLE
Fix Incorrect Data Type RVV Intrinsics 

### DIFF
--- a/simde/arm/neon/cge.h
+++ b/simde/arm/neon/cge.h
@@ -174,8 +174,8 @@ simde_vcgeq_s8(simde_int8x16_t a, simde_int8x16_t b) {
       r_.v128 = wasm_i8x16_ge(a_.v128, b_.v128);
     #elif defined(SIMDE_RISCV_V_NATIVE)
       vbool8_t result = __riscv_vmsge_vv_i8m1_b8(a_.sv128, b_.sv128, 16);
-      r_.sv128 = __riscv_vmv_v_x_i8m1(0, 16);
-      r_.sv128 = __riscv_vmerge_vxm_i8m1(r_.sv128, -1, result, 16);
+      r_.sv128 = __riscv_vmv_v_x_u8m1(0, 16);
+      r_.sv128 = __riscv_vmerge_vxm_u8m1(r_.sv128, -1, result, 16);
     #elif defined(SIMDE_VECTOR_SUBSCRIPT_OPS)
       r_.values = HEDLEY_REINTERPRET_CAST(__typeof__(r_.values), a_.values >= b_.values);
     #else
@@ -212,8 +212,8 @@ simde_vcgeq_s16(simde_int16x8_t a, simde_int16x8_t b) {
       r_.v128 = wasm_i16x8_ge(a_.v128, b_.v128);
     #elif defined(SIMDE_RISCV_V_NATIVE)
       vbool16_t result = __riscv_vmsge_vv_i16m1_b16(a_.sv128, b_.sv128, 8);
-      r_.sv128 = __riscv_vmv_v_x_i16m1(0, 8);
-      r_.sv128 = __riscv_vmerge_vxm_i16m1(r_.sv128, -1, result, 8);
+      r_.sv128 = __riscv_vmv_v_x_u16m1(0, 8);
+      r_.sv128 = __riscv_vmerge_vxm_u16m1(r_.sv128, -1, result, 8);
     #elif defined(SIMDE_VECTOR_SUBSCRIPT_OPS)
       r_.values = HEDLEY_REINTERPRET_CAST(__typeof__(r_.values), a_.values >= b_.values);
     #else
@@ -250,8 +250,8 @@ simde_vcgeq_s32(simde_int32x4_t a, simde_int32x4_t b) {
       r_.v128 = wasm_i32x4_ge(a_.v128, b_.v128);
     #elif defined(SIMDE_RISCV_V_NATIVE)
       vbool32_t result = __riscv_vmsge_vv_i32m1_b32(a_.sv128, b_.sv128, 4);
-      r_.sv128 = __riscv_vmv_v_x_i32m1(0, 4);
-      r_.sv128 = __riscv_vmerge_vxm_i32m1(r_.sv128, -1, result, 4);
+      r_.sv128 = __riscv_vmv_v_x_u32m1(0, 4);
+      r_.sv128 = __riscv_vmerge_vxm_u32m1(r_.sv128, -1, result, 4);
     #elif defined(SIMDE_VECTOR_SUBSCRIPT_OPS)
       r_.values = HEDLEY_REINTERPRET_CAST(__typeof__(r_.values), a_.values >= b_.values);
     #else
@@ -288,8 +288,8 @@ simde_vcgeq_s64(simde_int64x2_t a, simde_int64x2_t b) {
       r_.m128i = _mm_or_si128(_mm_cmpgt_epi64(a_.m128i, b_.m128i), _mm_cmpeq_epi64(a_.m128i, b_.m128i));
     #elif defined(SIMDE_RISCV_V_NATIVE)
       vbool64_t result = __riscv_vmsge_vv_i64m1_b64(a_.sv128, b_.sv128, 2);
-      r_.sv128 = __riscv_vmv_v_x_i64m1(0, 2);
-      r_.sv128 = __riscv_vmerge_vxm_i64m1(r_.sv128, -1, result, 2);
+      r_.sv128 = __riscv_vmv_v_x_u64m1(0, 2);
+      r_.sv128 = __riscv_vmerge_vxm_u64m1(r_.sv128, -1, result, 2);
     #elif defined(SIMDE_VECTOR_SUBSCRIPT_OPS)
       r_.values = HEDLEY_REINTERPRET_CAST(__typeof__(r_.values), a_.values >= b_.values);
     #else
@@ -591,8 +591,8 @@ simde_vcge_s8(simde_int8x8_t a, simde_int8x8_t b) {
       r_.m64 = _mm_or_si64(_mm_cmpgt_pi8(a_.m64, b_.m64), _mm_cmpeq_pi8(a_.m64, b_.m64));
     #elif defined(SIMDE_RISCV_V_NATIVE)
       vbool8_t result = __riscv_vmsge_vv_i8m1_b8(a_.sv64, b_.sv64, 8);
-      r_.sv64 = __riscv_vmv_v_x_i8m1(0, 8);
-      r_.sv64 = __riscv_vmerge_vxm_i8m1(r_.sv64, -1, result, 8);
+      r_.sv64 = __riscv_vmv_v_x_u8m1(0, 8);
+      r_.sv64 = __riscv_vmerge_vxm_u8m1(r_.sv64, -1, result, 8);
     #elif defined(SIMDE_VECTOR_SUBSCRIPT_OPS) && !defined(SIMDE_BUG_GCC_100762)
       r_.values = HEDLEY_REINTERPRET_CAST(__typeof__(r_.values), a_.values >= b_.values);
     #else

--- a/simde/arm/neon/cgt.h
+++ b/simde/arm/neon/cgt.h
@@ -235,8 +235,8 @@ simde_vcgtq_s8(simde_int8x16_t a, simde_int8x16_t b) {
       r_.v128 = wasm_i8x16_gt(a_.v128, b_.v128);
     #elif defined(SIMDE_RISCV_V_NATIVE)
       vbool8_t result = __riscv_vmsgt_vv_i8m1_b8(a_.sv128, b_.sv128, 16);
-      r_.sv128 = __riscv_vmv_v_x_i8m1(0, 16);
-      r_.sv128 = __riscv_vmerge_vxm_i8m1(r_.sv128, -1, result, 16);
+      r_.sv128 = __riscv_vmv_v_x_u8m1(0, 16);
+      r_.sv128 = __riscv_vmerge_vxm_u8m1(r_.sv128, -1, result, 16);
     #elif defined(SIMDE_VECTOR_SUBSCRIPT_OPS)
       r_.values = HEDLEY_REINTERPRET_CAST(__typeof__(r_.values), a_.values > b_.values);
     #else
@@ -273,8 +273,8 @@ simde_vcgtq_s16(simde_int16x8_t a, simde_int16x8_t b) {
       r_.v128 = wasm_i16x8_gt(a_.v128, b_.v128);
     #elif defined(SIMDE_RISCV_V_NATIVE)
       vbool16_t result = __riscv_vmsgt_vv_i16m1_b16(a_.sv128, b_.sv128, 8);
-      r_.sv128 = __riscv_vmv_v_x_i16m1(0, 8);
-      r_.sv128 = __riscv_vmerge_vxm_i16m1(r_.sv128, -1, result, 8);
+      r_.sv128 = __riscv_vmv_v_x_u16m1(0, 8);
+      r_.sv128 = __riscv_vmerge_vxm_u16m1(r_.sv128, -1, result, 8);
     #elif defined(SIMDE_VECTOR_SUBSCRIPT_OPS)
       r_.values = HEDLEY_REINTERPRET_CAST(__typeof__(r_.values), a_.values > b_.values);
     #else
@@ -311,8 +311,8 @@ simde_vcgtq_s32(simde_int32x4_t a, simde_int32x4_t b) {
       r_.v128 = wasm_i32x4_gt(a_.v128, b_.v128);
     #elif defined(SIMDE_RISCV_V_NATIVE)
       vbool32_t result = __riscv_vmsgt_vv_i32m1_b32(a_.sv128, b_.sv128, 4);
-      r_.sv128 = __riscv_vmv_v_x_i32m1(0, 4);
-      r_.sv128 = __riscv_vmerge_vxm_i32m1(r_.sv128, -1, result, 4);
+      r_.sv128 = __riscv_vmv_v_x_u32m1(0, 4);
+      r_.sv128 = __riscv_vmerge_vxm_u32m1(r_.sv128, -1, result, 4);
     #elif defined(SIMDE_VECTOR_SUBSCRIPT_OPS)
       r_.values = HEDLEY_REINTERPRET_CAST(__typeof__(r_.values), a_.values > b_.values);
     #else
@@ -354,8 +354,8 @@ simde_vcgtq_s64(simde_int64x2_t a, simde_int64x2_t b) {
       r_.m128i = _mm_shuffle_epi32(r, _MM_SHUFFLE(3,3,1,1));
     #elif defined(SIMDE_RISCV_V_NATIVE)
       vbool64_t result = __riscv_vmsgt_vv_i64m1_b64(a_.sv128, b_.sv128, 2);
-      r_.sv128 = __riscv_vmv_v_x_i64m1(0, 2);
-      r_.sv128 = __riscv_vmerge_vxm_i64m1(r_.sv128, -1, result, 2);
+      r_.sv128 = __riscv_vmv_v_x_u64m1(0, 2);
+      r_.sv128 = __riscv_vmerge_vxm_u64m1(r_.sv128, -1, result, 2);
     #elif defined(SIMDE_VECTOR_SUBSCRIPT_OPS)
       r_.values = HEDLEY_REINTERPRET_CAST(__typeof__(r_.values), a_.values > b_.values);
     #else
@@ -639,8 +639,8 @@ simde_vcgt_s8(simde_int8x8_t a, simde_int8x8_t b) {
       r_.m64 = _mm_cmpgt_pi8(a_.m64, b_.m64);
     #elif defined(SIMDE_RISCV_V_NATIVE)
       vbool8_t result = __riscv_vmsgt_vv_i8m1_b8(a_.sv64, b_.sv64, 8);
-      r_.sv64 = __riscv_vmv_v_x_i8m1(0, 8);
-      r_.sv64 = __riscv_vmerge_vxm_i8m1(r_.sv64, -1, result, 8);
+      r_.sv64 = __riscv_vmv_v_x_u8m1(0, 8);
+      r_.sv64 = __riscv_vmerge_vxm_u8m1(r_.sv64, -1, result, 8);
     #elif defined(SIMDE_VECTOR_SUBSCRIPT_OPS) && !defined(SIMDE_BUG_GCC_100762)
       r_.values = HEDLEY_REINTERPRET_CAST(__typeof__(r_.values), a_.values > b_.values);
     #else
@@ -673,8 +673,8 @@ simde_vcgt_s16(simde_int16x4_t a, simde_int16x4_t b) {
       r_.m64 = _mm_cmpgt_pi16(a_.m64, b_.m64);
     #elif defined(SIMDE_RISCV_V_NATIVE)
       vbool16_t result = __riscv_vmsgt_vv_i16m1_b16(a_.sv64, b_.sv64, 4);
-      r_.sv64 = __riscv_vmv_v_x_i16m1(0, 4);
-      r_.sv64 = __riscv_vmerge_vxm_i16m1(r_.sv64, -1, result, 4);
+      r_.sv64 = __riscv_vmv_v_x_u16m1(0, 4);
+      r_.sv64 = __riscv_vmerge_vxm_u16m1(r_.sv64, -1, result, 4);
     #elif defined(SIMDE_VECTOR_SUBSCRIPT_OPS) && !defined(SIMDE_BUG_GCC_100762)
       r_.values = HEDLEY_REINTERPRET_CAST(__typeof__(r_.values), a_.values > b_.values);
     #else
@@ -707,8 +707,8 @@ simde_vcgt_s32(simde_int32x2_t a, simde_int32x2_t b) {
       r_.m64 = _mm_cmpgt_pi32(a_.m64, b_.m64);
     #elif defined(SIMDE_RISCV_V_NATIVE)
       vbool32_t result = __riscv_vmsgt_vv_i32m1_b32(a_.sv64, b_.sv64, 2);
-      r_.sv64 = __riscv_vmv_v_x_i32m1(0, 2);
-      r_.sv64 = __riscv_vmerge_vxm_i32m1(r_.sv64, -1, result, 2);
+      r_.sv64 = __riscv_vmv_v_x_u32m1(0, 2);
+      r_.sv64 = __riscv_vmerge_vxm_u32m1(r_.sv64, -1, result, 2);
     #elif defined(SIMDE_VECTOR_SUBSCRIPT_OPS) && !defined(SIMDE_BUG_GCC_100762)
       r_.values = HEDLEY_REINTERPRET_CAST(__typeof__(r_.values), a_.values > b_.values);
     #else

--- a/simde/arm/neon/cle.h
+++ b/simde/arm/neon/cle.h
@@ -230,8 +230,8 @@ simde_vcleq_s8(simde_int8x16_t a, simde_int8x16_t b) {
       r_.v128 = wasm_i8x16_le(a_.v128, b_.v128);
     #elif defined(SIMDE_RISCV_V_NATIVE)
       vbool8_t result = __riscv_vmsle_vv_i8m1_b8(a_.sv128, b_.sv128, 16);
-      r_.sv128 = __riscv_vmv_v_x_i8m1(0, 16);
-      r_.sv128 = __riscv_vmerge_vxm_i8m1(r_.sv128, -1, result, 16);
+      r_.sv128 = __riscv_vmv_v_x_u8m1(0, 16);
+      r_.sv128 = __riscv_vmerge_vxm_u8m1(r_.sv128, -1, result, 16);
     #elif defined(SIMDE_VECTOR_SUBSCRIPT_OPS)
       r_.values = HEDLEY_REINTERPRET_CAST(__typeof__(r_.values), a_.values <= b_.values);
     #else
@@ -268,8 +268,8 @@ simde_vcleq_s16(simde_int16x8_t a, simde_int16x8_t b) {
       r_.v128 = wasm_i16x8_le(a_.v128, b_.v128);
     #elif defined(SIMDE_RISCV_V_NATIVE)
       vbool16_t result = __riscv_vmsle_vv_i16m1_b16(a_.sv128, b_.sv128, 8);
-      r_.sv128 = __riscv_vmv_v_x_i16m1(0, 8);
-      r_.sv128 = __riscv_vmerge_vxm_i16m1(r_.sv128, -1, result, 8);
+      r_.sv128 = __riscv_vmv_v_x_u16m1(0, 8);
+      r_.sv128 = __riscv_vmerge_vxm_u16m1(r_.sv128, -1, result, 8);
     #elif defined(SIMDE_VECTOR_SUBSCRIPT_OPS)
       r_.values = HEDLEY_REINTERPRET_CAST(__typeof__(r_.values), a_.values <= b_.values);
     #else
@@ -306,8 +306,8 @@ simde_vcleq_s32(simde_int32x4_t a, simde_int32x4_t b) {
       r_.v128 = wasm_i32x4_le(a_.v128, b_.v128);
     #elif defined(SIMDE_RISCV_V_NATIVE)
       vbool32_t result = __riscv_vmsle_vv_i32m1_b32(a_.sv128, b_.sv128, 4);
-      r_.sv128 = __riscv_vmv_v_x_i32m1(0, 4);
-      r_.sv128 = __riscv_vmerge_vxm_i32m1(r_.sv128, -1, result, 4);
+      r_.sv128 = __riscv_vmv_v_x_u32m1(0, 4);
+      r_.sv128 = __riscv_vmerge_vxm_u32m1(r_.sv128, -1, result, 4);
     #elif defined(SIMDE_VECTOR_SUBSCRIPT_OPS)
       r_.values = HEDLEY_REINTERPRET_CAST(__typeof__(r_.values), a_.values <= b_.values);
     #else
@@ -344,8 +344,8 @@ simde_vcleq_s64(simde_int64x2_t a, simde_int64x2_t b) {
       r_.m128i = _mm_or_si128(_mm_cmpgt_epi64(b_.m128i, a_.m128i), _mm_cmpeq_epi64(a_.m128i, b_.m128i));
     #elif defined(SIMDE_RISCV_V_NATIVE)
       vbool64_t result = __riscv_vmsle_vv_i64m1_b64(a_.sv128, b_.sv128, 2);
-      r_.sv128 = __riscv_vmv_v_x_i64m1(0, 2);
-      r_.sv128 = __riscv_vmerge_vxm_i64m1(r_.sv128, -1, result, 2);
+      r_.sv128 = __riscv_vmv_v_x_u64m1(0, 2);
+      r_.sv128 = __riscv_vmerge_vxm_u64m1(r_.sv128, -1, result, 2);
     #elif defined(SIMDE_VECTOR_SUBSCRIPT_OPS)
       r_.values = HEDLEY_REINTERPRET_CAST(__typeof__(r_.values), a_.values <= b_.values);
     #else
@@ -669,8 +669,8 @@ simde_vcle_s8(simde_int8x8_t a, simde_int8x8_t b) {
       r_.m64 = _mm_or_si64(_mm_cmpgt_pi8(b_.m64, a_.m64), _mm_cmpeq_pi8(a_.m64, b_.m64));
     #elif defined(SIMDE_RISCV_V_NATIVE)
       vbool8_t result = __riscv_vmsle_vv_i8m1_b8(a_.sv64, b_.sv64, 8);
-      r_.sv64 = __riscv_vmv_v_x_i8m1(0, 8);
-      r_.sv64 = __riscv_vmerge_vxm_i8m1(r_.sv64, -1, result, 8);
+      r_.sv64 = __riscv_vmv_v_x_u8m1(0, 8);
+      r_.sv64 = __riscv_vmerge_vxm_u8m1(r_.sv64, -1, result, 8);
     #elif defined(SIMDE_VECTOR_SUBSCRIPT_OPS) && !defined(SIMDE_BUG_GCC_100762)
       r_.values = HEDLEY_REINTERPRET_CAST(__typeof__(r_.values), a_.values <= b_.values);
     #else
@@ -703,8 +703,8 @@ simde_vcle_s16(simde_int16x4_t a, simde_int16x4_t b) {
       r_.m64 = _mm_or_si64(_mm_cmpgt_pi16(b_.m64, a_.m64), _mm_cmpeq_pi16(a_.m64, b_.m64));
     #elif defined(SIMDE_RISCV_V_NATIVE)
       vbool16_t result = __riscv_vmsle_vv_i16m1_b16(a_.sv64, b_.sv64, 4);
-      r_.sv64 = __riscv_vmv_v_x_i16m1(0, 4);
-      r_.sv64 = __riscv_vmerge_vxm_i16m1(r_.sv64, -1, result, 4);
+      r_.sv64 = __riscv_vmv_v_x_u16m1(0, 4);
+      r_.sv64 = __riscv_vmerge_vxm_u16m1(r_.sv64, -1, result, 4);
     #elif defined(SIMDE_VECTOR_SUBSCRIPT_OPS) && !defined(SIMDE_BUG_GCC_100762)
       r_.values = HEDLEY_REINTERPRET_CAST(__typeof__(r_.values), a_.values <= b_.values);
     #else
@@ -737,8 +737,8 @@ simde_vcle_s32(simde_int32x2_t a, simde_int32x2_t b) {
       r_.m64 = _mm_or_si64(_mm_cmpgt_pi32(b_.m64, a_.m64), _mm_cmpeq_pi32(a_.m64, b_.m64));
     #elif defined(SIMDE_RISCV_V_NATIVE)
       vbool32_t result = __riscv_vmsle_vv_i32m1_b32(a_.sv64, b_.sv64, 2);
-      r_.sv64 = __riscv_vmv_v_x_i32m1(0, 2);
-      r_.sv64 = __riscv_vmerge_vxm_i32m1(r_.sv64, -1, result, 2);
+      r_.sv64 = __riscv_vmv_v_x_u32m1(0, 2);
+      r_.sv64 = __riscv_vmerge_vxm_u32m1(r_.sv64, -1, result, 2);
     #elif defined(SIMDE_VECTOR_SUBSCRIPT_OPS) && !defined(SIMDE_BUG_GCC_100762)
       r_.values = HEDLEY_REINTERPRET_CAST(__typeof__(r_.values), a_.values <= b_.values);
     #else

--- a/simde/arm/neon/clt.h
+++ b/simde/arm/neon/clt.h
@@ -234,8 +234,8 @@ simde_vcltq_s8(simde_int8x16_t a, simde_int8x16_t b) {
       r_.v128 = wasm_i8x16_lt(a_.v128, b_.v128);
     #elif defined(SIMDE_RISCV_V_NATIVE)
       vbool8_t result = __riscv_vmslt_vv_i8m1_b8(a_.sv128, b_.sv128, 16);
-      r_.sv128 = __riscv_vmv_v_x_i8m1(0, 16);
-      r_.sv128 = __riscv_vmerge_vxm_i8m1(r_.sv128, -1, result, 16);
+      r_.sv128 = __riscv_vmv_v_x_u8m1(0, 16);
+      r_.sv128 = __riscv_vmerge_vxm_u8m1(r_.sv128, -1, result, 16);
     #elif defined(SIMDE_VECTOR_SUBSCRIPT_OPS)
       r_.values = HEDLEY_REINTERPRET_CAST(__typeof__(r_.values), a_.values < b_.values);
     #else
@@ -272,8 +272,8 @@ simde_vcltq_s16(simde_int16x8_t a, simde_int16x8_t b) {
       r_.v128 = wasm_i16x8_lt(a_.v128, b_.v128);
     #elif defined(SIMDE_RISCV_V_NATIVE)
       vbool16_t result = __riscv_vmslt_vv_i16m1_b16(a_.sv128, b_.sv128, 8);
-      r_.sv128 = __riscv_vmv_v_x_i16m1(0, 8);
-      r_.sv128 = __riscv_vmerge_vxm_i16m1(r_.sv128, -1, result, 8);
+      r_.sv128 = __riscv_vmv_v_x_u16m1(0, 8);
+      r_.sv128 = __riscv_vmerge_vxm_u16m1(r_.sv128, -1, result, 8);
     #elif defined(SIMDE_VECTOR_SUBSCRIPT_OPS)
       r_.values = HEDLEY_REINTERPRET_CAST(__typeof__(r_.values), a_.values < b_.values);
     #else
@@ -310,8 +310,8 @@ simde_vcltq_s32(simde_int32x4_t a, simde_int32x4_t b) {
       r_.v128 = wasm_i32x4_lt(a_.v128, b_.v128);
     #elif defined(SIMDE_RISCV_V_NATIVE)
       vbool32_t result = __riscv_vmslt_vv_i32m1_b32(a_.sv128, b_.sv128, 4);
-      r_.sv128 = __riscv_vmv_v_x_i32m1(0, 4);
-      r_.sv128 = __riscv_vmerge_vxm_i32m1(r_.sv128, -1, result, 4);
+      r_.sv128 = __riscv_vmv_v_x_u32m1(0, 4);
+      r_.sv128 = __riscv_vmerge_vxm_u32m1(r_.sv128, -1, result, 4);
     #elif defined(SIMDE_VECTOR_SUBSCRIPT_OPS)
       r_.values = HEDLEY_REINTERPRET_CAST(__typeof__(r_.values), a_.values < b_.values);
     #else
@@ -348,8 +348,8 @@ simde_vcltq_s64(simde_int64x2_t a, simde_int64x2_t b) {
       r_.m128i = _mm_cmpgt_epi64(b_.m128i, a_.m128i);
     #elif defined(SIMDE_RISCV_V_NATIVE)
       vbool64_t result = __riscv_vmslt_vv_i64m1_b64(a_.sv128, b_.sv128, 2);
-      r_.sv128 = __riscv_vmv_v_x_i64m1(0, 2);
-      r_.sv128 = __riscv_vmerge_vxm_i64m1(r_.sv128, -1, result, 2);
+      r_.sv128 = __riscv_vmv_v_x_u64m1(0, 2);
+      r_.sv128 = __riscv_vmerge_vxm_u64m1(r_.sv128, -1, result, 2);
     #elif defined(SIMDE_VECTOR_SUBSCRIPT_OPS)
       r_.values = HEDLEY_REINTERPRET_CAST(__typeof__(r_.values), a_.values < b_.values);
     #else
@@ -647,8 +647,8 @@ simde_vclt_s8(simde_int8x8_t a, simde_int8x8_t b) {
       r_.m64 = _mm_cmpgt_pi8(b_.m64, a_.m64);
     #elif defined(SIMDE_RISCV_V_NATIVE)
       vbool8_t result = __riscv_vmslt_vv_i8m1_b8(a_.sv64, b_.sv64, 8);
-      r_.sv64 = __riscv_vmv_v_x_i8m1(0, 8);
-      r_.sv64 = __riscv_vmerge_vxm_i8m1(r_.sv64, -1, result, 8);
+      r_.sv64 = __riscv_vmv_v_x_u8m1(0, 8);
+      r_.sv64 = __riscv_vmerge_vxm_u8m1(r_.sv64, -1, result, 8);
     #elif defined(SIMDE_VECTOR_SUBSCRIPT_OPS) && !defined(SIMDE_BUG_GCC_100762)
       r_.values = HEDLEY_REINTERPRET_CAST(__typeof__(r_.values), a_.values < b_.values);
     #else
@@ -681,8 +681,8 @@ simde_vclt_s16(simde_int16x4_t a, simde_int16x4_t b) {
       r_.m64 = _mm_cmpgt_pi16(b_.m64, a_.m64);
     #elif defined(SIMDE_RISCV_V_NATIVE)
       vbool16_t result = __riscv_vmslt_vv_i16m1_b16(a_.sv64, b_.sv64, 4);
-      r_.sv64 = __riscv_vmv_v_x_i16m1(0, 4);
-      r_.sv64 = __riscv_vmerge_vxm_i16m1(r_.sv64, -1, result, 4);
+      r_.sv64 = __riscv_vmv_v_x_u16m1(0, 4);
+      r_.sv64 = __riscv_vmerge_vxm_u16m1(r_.sv64, -1, result, 4);
     #elif defined(SIMDE_VECTOR_SUBSCRIPT_OPS) && !defined(SIMDE_BUG_GCC_100762)
       r_.values = HEDLEY_REINTERPRET_CAST(__typeof__(r_.values), a_.values < b_.values);
     #else
@@ -715,8 +715,8 @@ simde_vclt_s32(simde_int32x2_t a, simde_int32x2_t b) {
       r_.m64 = _mm_cmpgt_pi32(b_.m64, a_.m64);
     #elif defined(SIMDE_RISCV_V_NATIVE)
       vbool32_t result = __riscv_vmslt_vv_i32m1_b32(a_.sv64, b_.sv64, 2);
-      r_.sv64 = __riscv_vmv_v_x_i32m1(0, 2);
-      r_.sv64 = __riscv_vmerge_vxm_i32m1(r_.sv64, -1, result, 2);
+      r_.sv64 = __riscv_vmv_v_x_u32m1(0, 2);
+      r_.sv64 = __riscv_vmerge_vxm_u32m1(r_.sv64, -1, result, 2);
     #elif defined(SIMDE_VECTOR_SUBSCRIPT_OPS) && !defined(SIMDE_BUG_GCC_100762)
       r_.values = HEDLEY_REINTERPRET_CAST(__typeof__(r_.values), a_.values < b_.values);
     #else

--- a/simde/arm/neon/cnt.h
+++ b/simde/arm/neon/cnt.h
@@ -56,15 +56,17 @@ simde_vcnt_s8(simde_int8x8_t a) {
       a_ = simde_int8x8_to_private(a);
 
     #if defined(SIMDE_RISCV_V_NATIVE)
-      vuint8m1_t tmp = __riscv_vand_vv_u8m1(__riscv_vsrl_vx_u8m1(a_.sv64 , 1 , 8) , __riscv_vmv_v_x_u8m1(0x55 , 8) , 8);
-      a_.sv64 = __riscv_vsub_vv_u8m1(a_.sv64 , tmp , 8);
-      tmp = a_.sv64;
-      a_.sv64 = __riscv_vand_vv_u8m1(a_.sv64 , __riscv_vmv_v_x_u8m1(0x33 , 8) , 8);
+      vuint8m1_t p = __riscv_vreinterpret_v_i8m1_u8m1(a_.sv64);
+      vuint8m1_t tmp = __riscv_vand_vv_u8m1(__riscv_vsrl_vx_u8m1(p , 1 , 8) , __riscv_vmv_v_x_u8m1(0x55 , 8) , 8);
+      p = __riscv_vsub_vv_u8m1(p , tmp , 8);
+      tmp = p;
+      p = __riscv_vand_vv_u8m1(p , __riscv_vmv_v_x_u8m1(0x33 , 8) , 8);
       tmp = __riscv_vand_vv_u8m1(__riscv_vsrl_vx_u8m1(tmp , 2 , 8) , __riscv_vmv_v_x_u8m1(0x33 , 8) , 8);
-      a_.sv64 = __riscv_vadd_vv_u8m1(a_.sv64 , tmp , 8);
-      tmp = __riscv_vsrl_vx_u8m1(a_.sv64, 4 , 8);
-      a_.sv64 = __riscv_vadd_vv_u8m1(a_.sv64 , tmp , 8);
-      r_.sv64 = __riscv_vand_vv_u8m1(a_.sv64 , __riscv_vmv_v_x_u8m1(0xf , 8) , 8);
+      p = __riscv_vadd_vv_u8m1(p , tmp , 8);
+      tmp = __riscv_vsrl_vx_u8m1(p, 4 , 8);
+      p = __riscv_vadd_vv_u8m1(p , tmp , 8);
+      p = __riscv_vand_vv_u8m1(p , __riscv_vmv_v_x_u8m1(0xf , 8) , 8);
+      r_.sv64 = __riscv_vreinterpret_v_u8m1_i8m1(p);
     #else
       SIMDE_VECTORIZE
       for (size_t i = 0 ; i < (sizeof(r_.values) / sizeof(r_.values[0])) ; i++) {

--- a/simde/arm/neon/qshlu_n.h
+++ b/simde/arm/neon/qshlu_n.h
@@ -125,7 +125,7 @@ simde_vqshlu_n_s8(simde_int8x8_t a, const int n)
     simde_uint8x8_private r_;
     #if defined(SIMDE_RISCV_V_NATIVE)
       vuint8m1_t shift = __riscv_vsll_vx_u8m1(__riscv_vreinterpret_v_i8m1_u8m1(a_.sv64), n, 8);
-      r_.sv64 = __riscv_vmerge_vxm_u8m1(shift, UINT8_MAX, __riscv_vmsne_vv_u8m1_b8(__riscv_vsrl_vx_u8m1(shift, n, 8), a_.sv64, 8), 8);
+      r_.sv64 = __riscv_vmerge_vxm_u8m1(shift, UINT8_MAX, __riscv_vmsne_vv_u8m1_b8(__riscv_vsrl_vx_u8m1(shift, n, 8), __riscv_vreinterpret_v_i8m1_u8m1(a_.sv64), 8), 8);
       r_.sv64 = __riscv_vmerge_vxm_u8m1(r_.sv64, 0, __riscv_vmslt_vx_i8m1_b8(a_.sv64, 0, 8), 8);
     #elif defined(SIMDE_VECTOR_SUBSCRIPT_SCALAR) && !defined(SIMDE_BUG_GCC_100762)
       __typeof__(r_.values) shifted = HEDLEY_REINTERPRET_CAST(__typeof__(r_.values), a_.values) << n;
@@ -174,7 +174,7 @@ simde_vqshlu_n_s16(simde_int16x4_t a, const int n)
     simde_uint16x4_private r_;
     #if defined(SIMDE_RISCV_V_NATIVE)
       vuint16m1_t shift = __riscv_vsll_vx_u16m1(__riscv_vreinterpret_v_i16m1_u16m1(a_.sv64), n, 4);
-      r_.sv64 = __riscv_vmerge_vxm_u16m1(shift, UINT16_MAX, __riscv_vmsne_vv_u16m1_b16(__riscv_vsrl_vx_u16m1(shift, n, 4), a_.sv64, 4), 4);
+      r_.sv64 = __riscv_vmerge_vxm_u16m1(shift, UINT16_MAX, __riscv_vmsne_vv_u16m1_b16(__riscv_vsrl_vx_u16m1(shift, n, 4), __riscv_vreinterpret_v_i16m1_u16m1(a_.sv64), 4), 4);
       r_.sv64 = __riscv_vmerge_vxm_u16m1(r_.sv64, 0, __riscv_vmslt_vx_i16m1_b16(a_.sv64, 0, 4), 4);
     #elif defined(SIMDE_VECTOR_SUBSCRIPT_SCALAR) && !defined(SIMDE_BUG_GCC_100762)
       __typeof__(r_.values) shifted = HEDLEY_REINTERPRET_CAST(__typeof__(r_.values), a_.values) << n;
@@ -226,7 +226,7 @@ simde_vqshlu_n_s32(simde_int32x2_t a, const int n)
 
     #if defined(SIMDE_RISCV_V_NATIVE)
       vuint32m1_t shift = __riscv_vsll_vx_u32m1(__riscv_vreinterpret_v_i32m1_u32m1(a_.sv64), n, 2);
-      r_.sv64 = __riscv_vmerge_vxm_u32m1(shift, UINT32_MAX, __riscv_vmsne_vv_u32m1_b32(__riscv_vsrl_vx_u32m1(shift, n, 2), a_.sv64, 2), 2);
+      r_.sv64 = __riscv_vmerge_vxm_u32m1(shift, UINT32_MAX, __riscv_vmsne_vv_u32m1_b32(__riscv_vsrl_vx_u32m1(shift, n, 2), __riscv_vreinterpret_v_i32m1_u32m1(a_.sv64), 2), 2);
       r_.sv64 = __riscv_vmerge_vxm_u32m1(r_.sv64, 0, __riscv_vmslt_vx_i32m1_b32(a_.sv64, 0, 2), 2);
     #elif defined(SIMDE_VECTOR_SUBSCRIPT_SCALAR) && !defined(SIMDE_BUG_GCC_100762)
       __typeof__(r_.values) shifted = HEDLEY_REINTERPRET_CAST(__typeof__(r_.values), a_.values) << n;
@@ -277,7 +277,7 @@ simde_vqshlu_n_s64(simde_int64x1_t a, const int n)
 
     #if defined(SIMDE_RISCV_V_NATIVE)
       vuint64m1_t shift = __riscv_vsll_vx_u64m1(__riscv_vreinterpret_v_i64m1_u64m1(a_.sv64), n, 1);
-      r_.sv64 = __riscv_vmerge_vxm_u64m1(shift, UINT64_MAX, __riscv_vmsne_vv_u64m1_b64(__riscv_vsrl_vx_u64m1(shift, n, 1), a_.sv64, 1), 1);
+      r_.sv64 = __riscv_vmerge_vxm_u64m1(shift, UINT64_MAX, __riscv_vmsne_vv_u64m1_b64(__riscv_vsrl_vx_u64m1(shift, n, 1), __riscv_vreinterpret_v_i64m1_u64m1(a_.sv64), 1), 1);
       r_.sv64 = __riscv_vmerge_vxm_u64m1(r_.sv64, 0, __riscv_vmslt_vx_i64m1_b64(a_.sv64, 0, 1), 1);
     #elif defined(SIMDE_VECTOR_SUBSCRIPT_SCALAR)
       __typeof__(r_.values) shifted = HEDLEY_REINTERPRET_CAST(__typeof__(r_.values), a_.values) << n;
@@ -321,7 +321,7 @@ simde_vqshluq_n_s8(simde_int8x16_t a, const int n)
     r_.v128 = wasm_v128_andnot(r_.v128, wasm_i8x16_shr(a_.v128, 7));
   #elif defined(SIMDE_RISCV_V_NATIVE)
       vuint8m1_t shift = __riscv_vsll_vx_u8m1(__riscv_vreinterpret_v_i8m1_u8m1(a_.sv128), n, 16);
-      r_.sv128 = __riscv_vmerge_vxm_u8m1(shift, UINT8_MAX, __riscv_vmsne_vv_u8m1_b8(__riscv_vsrl_vx_u8m1(shift, n, 16), a_.sv128, 16), 16);
+      r_.sv128 = __riscv_vmerge_vxm_u8m1(shift, UINT8_MAX, __riscv_vmsne_vv_u8m1_b8(__riscv_vsrl_vx_u8m1(shift, n, 16), __riscv_vreinterpret_v_i8m1_u8m1(a_.sv128), 16), 16);
       r_.sv128 = __riscv_vmerge_vxm_u8m1(r_.sv128, 0, __riscv_vmslt_vx_i8m1_b8(a_.sv128, 0, 16), 16);
   #elif defined(SIMDE_VECTOR_SUBSCRIPT_SCALAR)
     __typeof__(r_.values) shifted = HEDLEY_REINTERPRET_CAST(__typeof__(r_.values), a_.values) << n;
@@ -364,7 +364,7 @@ simde_vqshluq_n_s16(simde_int16x8_t a, const int n)
     r_.v128 = wasm_v128_andnot(r_.v128, wasm_i16x8_shr(a_.v128, 15));
   #elif defined(SIMDE_RISCV_V_NATIVE)
       vuint16m1_t shift = __riscv_vsll_vx_u16m1(__riscv_vreinterpret_v_i16m1_u16m1(a_.sv128), n, 8);
-      r_.sv128 = __riscv_vmerge_vxm_u16m1(shift, UINT16_MAX, __riscv_vmsne_vv_u16m1_b16(__riscv_vsrl_vx_u16m1(shift, n, 8), a_.sv128, 8), 8);
+      r_.sv128 = __riscv_vmerge_vxm_u16m1(shift, UINT16_MAX, __riscv_vmsne_vv_u16m1_b16(__riscv_vsrl_vx_u16m1(shift, n, 8), __riscv_vreinterpret_v_i16m1_u16m1(a_.sv128), 8), 8);
       r_.sv128 = __riscv_vmerge_vxm_u16m1(r_.sv128, 0, __riscv_vmslt_vx_i16m1_b16(a_.sv128, 0, 8), 8);
   #elif defined(SIMDE_VECTOR_SUBSCRIPT_SCALAR)
     __typeof__(r_.values) shifted = HEDLEY_REINTERPRET_CAST(__typeof__(r_.values), a_.values) << n;
@@ -407,7 +407,7 @@ simde_vqshluq_n_s32(simde_int32x4_t a, const int n)
     r_.v128 = wasm_v128_andnot(r_.v128, wasm_i32x4_shr(a_.v128, 31));
   #elif defined(SIMDE_RISCV_V_NATIVE)
       vuint32m1_t shift = __riscv_vsll_vx_u32m1(__riscv_vreinterpret_v_i32m1_u32m1(a_.sv128), n, 4);
-      r_.sv128 = __riscv_vmerge_vxm_u32m1(shift, UINT32_MAX, __riscv_vmsne_vv_u32m1_b32(__riscv_vsrl_vx_u32m1(shift, n, 4), a_.sv128, 4), 4);
+      r_.sv128 = __riscv_vmerge_vxm_u32m1(shift, UINT32_MAX, __riscv_vmsne_vv_u32m1_b32(__riscv_vsrl_vx_u32m1(shift, n, 4), __riscv_vreinterpret_v_i32m1_u32m1(a_.sv128), 4), 4);
       r_.sv128 = __riscv_vmerge_vxm_u32m1(r_.sv128, 0, __riscv_vmslt_vx_i32m1_b32(a_.sv128, 0, 4), 4);
   #elif defined(SIMDE_VECTOR_SUBSCRIPT_SCALAR)
     __typeof__(r_.values) shifted = HEDLEY_REINTERPRET_CAST(__typeof__(r_.values), a_.values) << n;
@@ -450,7 +450,7 @@ simde_vqshluq_n_s64(simde_int64x2_t a, const int n)
     r_.v128 = wasm_v128_andnot(r_.v128, wasm_i64x2_shr(a_.v128, 63));
   #elif defined(SIMDE_RISCV_V_NATIVE)
       vuint64m1_t shift = __riscv_vsll_vx_u64m1(__riscv_vreinterpret_v_i64m1_u64m1(a_.sv128), n, 2);
-      r_.sv128 = __riscv_vmerge_vxm_u64m1(shift, UINT64_MAX, __riscv_vmsne_vv_u64m1_b64(__riscv_vsrl_vx_u64m1(shift, n, 2), a_.sv128, 2), 2);
+      r_.sv128 = __riscv_vmerge_vxm_u64m1(shift, UINT64_MAX, __riscv_vmsne_vv_u64m1_b64(__riscv_vsrl_vx_u64m1(shift, n, 2), __riscv_vreinterpret_v_i64m1_u64m1(a_.sv128), 2), 2);
       r_.sv128 = __riscv_vmerge_vxm_u64m1(r_.sv128, 0, __riscv_vmslt_vx_i64m1_b64(a_.sv128, 0, 2), 2);
   #elif defined(SIMDE_VECTOR_SUBSCRIPT_SCALAR)
     __typeof__(r_.values) shifted = HEDLEY_REINTERPRET_CAST(__typeof__(r_.values), a_.values) << n;

--- a/simde/arm/neon/reinterpret.h
+++ b/simde/arm/neon/reinterpret.h
@@ -1764,7 +1764,7 @@ simde_vreinterpret_u16_s16(simde_int16x4_t a) {
     simde_uint16x4_private r_;
     simde_int16x4_private a_ = simde_int16x4_to_private(a);
     #if defined(SIMDE_RISCV_V_NATIVE)
-      r_.sv64 = __riscv_vreinterpret_v_u16m1_i16m1(a_.sv64);
+      r_.sv64 = __riscv_vreinterpret_v_i16m1_u16m1(a_.sv64);
     #else
       simde_memcpy(&r_, &a_, sizeof(r_));
     #endif
@@ -1954,7 +1954,7 @@ simde_vreinterpretq_u16_s16(simde_int16x8_t a) {
     simde_uint16x8_private r_;
     simde_int16x8_private a_ = simde_int16x8_to_private(a);
     #if defined(SIMDE_RISCV_V_NATIVE)
-      r_.sv128 = __riscv_vreinterpret_v_u16m1_i16m1(a_.sv128);
+      r_.sv128 = __riscv_vreinterpret_v_i16m1_u16m1(a_.sv128);
     #else
       simde_memcpy(&r_, &a_, sizeof(r_));
     #endif

--- a/simde/arm/neon/shl.h
+++ b/simde/arm/neon/shl.h
@@ -145,7 +145,7 @@ simde_vshl_s8 (const simde_int8x8_t a, const simde_int8x8_t b) {
     #else
       #if defined(SIMDE_RISCV_V_NATIVE)
         vint8m1_t bit_shift_rst = __riscv_vmerge_vxm_i8m1(
-         __riscv_vsll_vv_i8m1 (a_.sv64, b_.sv64, 8), 0, __riscv_vmsge_vx_i8m1_b8(b_.sv64, 8, 8), 8);
+         __riscv_vsll_vv_i8m1 (a_.sv64, __riscv_vreinterpret_v_i8m1_u8m1(b_.sv64), 8), 0, __riscv_vmsge_vx_i8m1_b8(b_.sv64, 8, 8), 8);
         vint8m1_t b_abs =  __riscv_vmax_vv_i8m1 (b_.sv64, __riscv_vneg_v_i8m1 (b_.sv64, 8), 8);
         vuint8m1_t u_b_abs = __riscv_vreinterpret_v_i8m1_u8m1 (b_abs);
         vint8m1_t scal_shift_rst = __riscv_vmerge_vvm_i8m1(__riscv_vsra_vv_i8m1 (a_.sv64, u_b_abs, 8), \
@@ -192,7 +192,7 @@ simde_vshl_s16 (const simde_int16x4_t a, const simde_int16x4_t b) {
     #else
       #if defined(SIMDE_RISCV_V_NATIVE)
         vint8mf2_t b_8mf2 = __riscv_vncvt_x_x_w_i8mf2 (b_.sv64, 4);
-        vint16m1_t bit_shift_rst = __riscv_vmerge_vxm_i16m1(__riscv_vsll_vv_i16m1 (a_.sv64, b_.sv64, 4), 0 \
+        vint16m1_t bit_shift_rst = __riscv_vmerge_vxm_i16m1(__riscv_vsll_vv_i16m1 (a_.sv64, __riscv_vreinterpret_v_i16m1_u16m1(b_.sv64), 4), 0 \
           , __riscv_vmsge_vx_i8mf2_b16(b_8mf2, 16, 8), 4);
         vint16m1_t b_abs =  __riscv_vmax_vv_i16m1 (b_.sv64, __riscv_vneg_v_i16m1 (b_.sv64, 4), 4);
         vuint16m1_t u_b_abs = __riscv_vreinterpret_v_i16m1_u16m1 (b_abs);
@@ -241,7 +241,7 @@ simde_vshl_s32 (const simde_int32x2_t a, const simde_int32x2_t b) {
     #else
       #if defined(SIMDE_RISCV_V_NATIVE)
         vint8mf4_t b_8mf4 = __riscv_vncvt_x_x_w_i8mf4 (__riscv_vncvt_x_x_w_i16mf2 (b_.sv64, 2), 4);
-        vint32m1_t bit_shift_rst = __riscv_vmerge_vxm_i32m1(__riscv_vsll_vv_i32m1 (a_.sv64, b_.sv64, 2), 0
+        vint32m1_t bit_shift_rst = __riscv_vmerge_vxm_i32m1(__riscv_vsll_vv_i32m1 (a_.sv64, __riscv_vreinterpret_v_i32m1_u32m1(b_.sv64), 2), 0
           , __riscv_vmsge_vx_i8mf4_b32(b_8mf4, 32, 2), 2);
         vint32m1_t b_abs =  __riscv_vmax_vv_i32m1 (b_.sv64, __riscv_vneg_v_i32m1 (b_.sv64, 2), 2);
         vuint32m1_t u_b_abs = __riscv_vreinterpret_v_i32m1_u32m1 (b_abs);
@@ -301,7 +301,7 @@ simde_vshl_s64 (const simde_int64x1_t a, const simde_int64x1_t b) {
     #else
       #if defined(SIMDE_RISCV_V_NATIVE)
         vint8mf8_t b_8mf8 = __riscv_vncvt_x_x_w_i8mf8 (__riscv_vncvt_x_x_w_i16mf4 (__riscv_vncvt_x_x_w_i32mf2 (b_.sv64, 1), 2), 4);
-        vint64m1_t bit_shift_rst = __riscv_vmerge_vxm_i64m1(__riscv_vsll_vv_i64m1 (a_.sv64, b_.sv64, 1), 0
+        vint64m1_t bit_shift_rst = __riscv_vmerge_vxm_i64m1(__riscv_vsll_vv_i64m1 (a_.sv64, __riscv_vreinterpret_v_i64m1_u64m1(b_.sv64), 1), 0
           , __riscv_vmsge_vx_i8mf8_b64(b_8mf8, 64, 1), 1);
         vint64m1_t b_abs =  __riscv_vmax_vv_i64m1 (b_.sv64, __riscv_vneg_v_i64m1 (b_.sv64, 1), 1);
         vuint64m1_t u_b_abs = __riscv_vreinterpret_v_i64m1_u64m1 (b_abs);
@@ -568,7 +568,7 @@ simde_vshlq_s8 (const simde_int8x16_t a, const simde_int8x16_t b) {
       r_.m128i = _mm256_cvtepi16_epi8(r256);
     #else
       #if defined(SIMDE_RISCV_V_NATIVE)
-        vint8m1_t bit_shift_rst = __riscv_vmerge_vxm_i8m1(__riscv_vsll_vv_i8m1 (a_.sv128, b_.sv128, 16), \
+        vint8m1_t bit_shift_rst = __riscv_vmerge_vxm_i8m1(__riscv_vsll_vv_i8m1 (a_.sv128, __riscv_vreinterpret_v_i8m1_u8m1(b_.sv128), 16), \
           0, __riscv_vmsge_vx_i8m1_b8(b_.sv128, 8, 16), 16);
         vint8m1_t b_abs =  __riscv_vmax_vv_i8m1 (b_.sv128, __riscv_vneg_v_i8m1 (b_.sv128, 16), 16);
         vuint8m1_t u_b_abs = __riscv_vreinterpret_v_i8m1_u8m1 (b_abs);
@@ -641,7 +641,7 @@ simde_vshlq_s16 (const simde_int16x8_t a, const simde_int16x8_t b) {
         vint8mf2_t b_8mf2_abs = __riscv_vmax_vv_i8mf2 (b_8mf2, __riscv_vneg_v_i8mf2 (b_8mf2, 16), 16);
         vuint8mf2_t u_b_8mf2_abs = __riscv_vreinterpret_v_i8mf2_u8mf2(b_8mf2_abs);
         vuint16m1_t u_b_abs = __riscv_vwcvtu_x_x_v_u16m1 (u_b_8mf2_abs, 16);
-        vint16m1_t bit_shift_rst = __riscv_vmerge_vxm_i16m1(__riscv_vsll_vv_i16m1 (a_.sv128, b_.sv128, 8), 0, \
+        vint16m1_t bit_shift_rst = __riscv_vmerge_vxm_i16m1(__riscv_vsll_vv_i16m1 (a_.sv128, __riscv_vreinterpret_v_i16m1_u16m1(b_.sv128), 8), 0, \
           __riscv_vmsge_vx_i8mf2_b16(b_8mf2, 16, 16), 8);
         vint16m1_t scal_shift_rst = __riscv_vmerge_vvm_i16m1(__riscv_vsra_vv_i16m1 (a_.sv128, u_b_abs, 8),
           __riscv_vsra_vx_i16m1(a_.sv128, 15, 8), __riscv_vmsle_vx_i8mf2_b16(b_8mf2, -16, 16), 8);
@@ -705,7 +705,7 @@ simde_vshlq_s32 (const simde_int32x4_t a, const simde_int32x4_t b) {
         vint8mf4_t b_8mf4_abs =  __riscv_vmax_vv_i8mf4 (b_8mf4, __riscv_vneg_v_i8mf4 (b_8mf4, 16), 16);
         vuint8mf4_t u_b_8mf4_abs = __riscv_vreinterpret_v_i8mf4_u8mf4 (b_8mf4_abs);
         vuint32m1_t u_b_abs = __riscv_vwcvtu_x_x_v_u32m1 (__riscv_vwcvtu_x_x_v_u16mf2 (u_b_8mf4_abs, 16), 8);
-        vint32m1_t bit_shift_rst = __riscv_vmerge_vxm_i32m1(__riscv_vsll_vv_i32m1 (a_.sv128, b_.sv128, 4), 0,
+        vint32m1_t bit_shift_rst = __riscv_vmerge_vxm_i32m1(__riscv_vsll_vv_i32m1 (a_.sv128, __riscv_vreinterpret_v_i32m1_u32m1(b_.sv128), 4), 0,
           __riscv_vmsge_vx_i8mf4_b32(b_8mf4, 32, 16), 4);
         vint32m1_t scal_shift_rst = __riscv_vmerge_vvm_i32m1(__riscv_vsra_vv_i32m1 (a_.sv128, u_b_abs, 4), \
           __riscv_vsra_vx_i32m1(a_.sv128, 31, 4), __riscv_vmsle_vx_i8mf4_b32(b_8mf4, -32, 4), 4);
@@ -778,7 +778,7 @@ simde_vshlq_s64 (const simde_int64x2_t a, const simde_int64x2_t b) {
         vint8mf8_t b_8mf8_abs =  __riscv_vmax_vv_i8mf8 (b_8mf8, __riscv_vneg_v_i8mf8 (b_8mf8, 16), 16);
         vuint8mf8_t u_b_8mf8_abs = __riscv_vreinterpret_v_i8mf8_u8mf8 (b_8mf8_abs);
         vuint64m1_t u_b_abs = __riscv_vwcvtu_x_x_v_u64m1(__riscv_vwcvtu_x_x_v_u32mf2 (__riscv_vwcvtu_x_x_v_u16mf4(u_b_8mf8_abs, 16), 8), 4);
-        vint64m1_t bit_shift_rst = __riscv_vmerge_vxm_i64m1(__riscv_vsll_vv_i64m1 (a_.sv128, b_.sv128, 2), 0, __riscv_vmsge_vx_i8mf8_b64(b_8mf8, 64, 2), 2);
+        vint64m1_t bit_shift_rst = __riscv_vmerge_vxm_i64m1(__riscv_vsll_vv_i64m1 (a_.sv128, __riscv_vreinterpret_v_i64m1_u64m1(b_.sv128), 2), 0, __riscv_vmsge_vx_i8mf8_b64(b_8mf8, 64, 2), 2);
         vint64m1_t scal_shift_rst = __riscv_vmerge_vvm_i64m1(__riscv_vsra_vv_i64m1 (a_.sv128, u_b_abs, 2)
           , __riscv_vsra_vx_i64m1(a_.sv128, 63, 2), __riscv_vmsle_vx_i8mf8_b64(b_8mf8, -64, 2), 2);
         r_.sv128 = __riscv_vmerge_vvm_i64m1 (bit_shift_rst, scal_shift_rst, __riscv_vmslt_vx_i8mf8_b64 (b_8mf8, 0, 16), 2);


### PR DESCRIPTION
Fix Incorrect Data Type RVV Intrinsics in 8 files which are listed below:
cge, cgt, cle, clt, cnt, qshlu_n, reinterpret, shl